### PR TITLE
feat: implement multicall for portfolio page

### DIFF
--- a/tinlake-ui/components/Header/index.tsx
+++ b/tinlake-ui/components/Header/index.tsx
@@ -160,7 +160,7 @@ const Header: React.FC<Props> = (props: Props) => {
                       <TokenLogo src={`/static/DAI.svg`} />
                       <Box>
                         <Holdings>
-                          {addThousandsSeparators(toPrecision(baseToDisplay(portfolio.totalValue, 22), 0))}
+                          {addThousandsSeparators(toPrecision(baseToDisplay(portfolio.totalValue, 18), 0))}
                         </Holdings>
                         <Desc>Portfolio Value</Desc>
                       </Box>

--- a/tinlake-ui/components/Header/index.tsx
+++ b/tinlake-ui/components/Header/index.tsx
@@ -53,11 +53,11 @@ const Header: React.FC<Props> = (props: Props) => {
   const dispatch = useDispatch()
 
   React.useEffect(() => {
-    if (address) dispatch(loadPortfolio(address))
+    if (address) dispatch(loadPortfolio(address, props.ipfsPools))
   }, [])
 
   React.useEffect(() => {
-    if (address) dispatch(loadPortfolio(address))
+    if (address) dispatch(loadPortfolio(address, props.ipfsPools))
   }, [address])
 
   const connectAccount = async () => {
@@ -160,7 +160,7 @@ const Header: React.FC<Props> = (props: Props) => {
                       <TokenLogo src={`/static/DAI.svg`} />
                       <Box>
                         <Holdings>
-                          {addThousandsSeparators(toPrecision(baseToDisplay(portfolio.totalValue, 18), 0))}
+                          {addThousandsSeparators(toPrecision(baseToDisplay(portfolio.totalValue, 22), 0))}
                         </Holdings>
                         <Desc>Portfolio Value</Desc>
                       </Box>

--- a/tinlake-ui/config.ts
+++ b/tinlake-ui/config.ts
@@ -65,6 +65,7 @@ export interface Pool extends BasePool {
     COLLATERAL_NFT: string
     SENIOR_TOKEN: string
     JUNIOR_TOKEN: string
+    ASSESSOR: string
   }
   contractConfig?: {
     JUNIOR_OPERATOR: 'ALLOWANCE_OPERATOR'

--- a/tinlake-ui/containers/Portfolio/index.tsx
+++ b/tinlake-ui/containers/Portfolio/index.tsx
@@ -120,7 +120,7 @@ const Portfolio: React.FC<Props> = (props: Props) => {
           <Cont>
             <TokenLogo src={`/static/DROP_final.svg`} />
             <Value>
-              <NumberDisplay value={baseToDisplay(totalDropValue, 22)} precision={0} />
+              <NumberDisplay value={baseToDisplay(totalDropValue, 18)} precision={0} />
             </Value>{' '}
             <Unit>DAI</Unit>
           </Cont>
@@ -137,7 +137,7 @@ const Portfolio: React.FC<Props> = (props: Props) => {
           <Cont>
             <TokenLogo src={`/static/TIN_final.svg`} />
             <Value>
-              <NumberDisplay value={baseToDisplay(totalTinValue, 22)} precision={0} />
+              <NumberDisplay value={baseToDisplay(totalTinValue, 18)} precision={0} />
             </Value>{' '}
             <Unit>DAI</Unit>
           </Cont>
@@ -194,7 +194,6 @@ const Portfolio: React.FC<Props> = (props: Props) => {
                     value={baseToDisplay(tokenBalance.balance, 18)}
                   />
                 </DataCol>
-
                 <DataCol>
                   <NumberDisplay
                     precision={4}
@@ -207,7 +206,13 @@ const Portfolio: React.FC<Props> = (props: Props) => {
                         </>
                       )
                     }
-                    value={baseToDisplay(tokenBalance.value, 27)}
+                    value={baseToDisplay(
+                      tokenBalance.value
+                        .mul(new BN(10).pow(new BN(7)))
+                        .div(tokenBalance.balance)
+                        .mul(new BN(10).pow(new BN(20))),
+                      27
+                    )}
                   />
                 </DataCol>
                 <DataCol>
@@ -223,7 +228,7 @@ const Portfolio: React.FC<Props> = (props: Props) => {
                         </>
                       )
                     }
-                    value={baseToDisplay(tokenBalance.value.mul(tokenBalance.balance), 45)}
+                    value={baseToDisplay(tokenBalance.value, 18)}
                   />
                 </DataCol>
               </PoolRow>

--- a/tinlake-ui/containers/Portfolio/index.tsx
+++ b/tinlake-ui/containers/Portfolio/index.tsx
@@ -194,6 +194,7 @@ const Portfolio: React.FC<Props> = (props: Props) => {
                     value={baseToDisplay(tokenBalance.balance, 18)}
                   />
                 </DataCol>
+
                 <DataCol>
                   <NumberDisplay
                     precision={4}
@@ -215,6 +216,7 @@ const Portfolio: React.FC<Props> = (props: Props) => {
                     )}
                   />
                 </DataCol>
+
                 <DataCol>
                   <NumberDisplay
                     precision={0}

--- a/tinlake-ui/containers/Portfolio/index.tsx
+++ b/tinlake-ui/containers/Portfolio/index.tsx
@@ -44,11 +44,11 @@ const Portfolio: React.FC<Props> = (props: Props) => {
 
   React.useEffect(() => {
     dispatch(loadPools(props.ipfsPools))
-    if (address) dispatch(loadPortfolio(address))
+    if (address) dispatch(loadPortfolio(address, props.ipfsPools))
   }, [])
 
   React.useEffect(() => {
-    if (address) dispatch(loadPortfolio(address))
+    if (address) dispatch(loadPortfolio(address, props.ipfsPools))
   }, [address])
 
   const getPool = (tokenBalance: TokenBalance) => {
@@ -120,7 +120,7 @@ const Portfolio: React.FC<Props> = (props: Props) => {
           <Cont>
             <TokenLogo src={`/static/DROP_final.svg`} />
             <Value>
-              <NumberDisplay value={baseToDisplay(totalDropValue, 18)} precision={0} />
+              <NumberDisplay value={baseToDisplay(totalDropValue, 22)} precision={0} />
             </Value>{' '}
             <Unit>DAI</Unit>
           </Cont>
@@ -137,7 +137,7 @@ const Portfolio: React.FC<Props> = (props: Props) => {
           <Cont>
             <TokenLogo src={`/static/TIN_final.svg`} />
             <Value>
-              <NumberDisplay value={baseToDisplay(totalTinValue, 18)} precision={0} />
+              <NumberDisplay value={baseToDisplay(totalTinValue, 22)} precision={0} />
             </Value>{' '}
             <Unit>DAI</Unit>
           </Cont>
@@ -207,16 +207,9 @@ const Portfolio: React.FC<Props> = (props: Props) => {
                         </>
                       )
                     }
-                    value={baseToDisplay(
-                      tokenBalance.value
-                        .mul(new BN(10).pow(new BN(7)))
-                        .div(tokenBalance.balance)
-                        .mul(new BN(10).pow(new BN(20))),
-                      27
-                    )}
+                    value={baseToDisplay(tokenBalance.value, 27)}
                   />
                 </DataCol>
-
                 <DataCol>
                   <NumberDisplay
                     precision={0}
@@ -230,7 +223,7 @@ const Portfolio: React.FC<Props> = (props: Props) => {
                         </>
                       )
                     }
-                    value={baseToDisplay(tokenBalance.value, 18)}
+                    value={baseToDisplay(tokenBalance.value.mul(tokenBalance.balance), 45)}
                   />
                 </DataCol>
               </PoolRow>

--- a/tinlake-ui/ducks/portfolio.ts
+++ b/tinlake-ui/ducks/portfolio.ts
@@ -122,13 +122,13 @@ export function loadPortfolio(
        * overwrites the values in tokenBalances that were retrieved from
        * the subgraph with the values from the multicall updates
        */
-      const tokenBalancesUpdates = tokenBalances.map((balance: TokenBalance) => ({
+      const updatedTokenBalances = tokenBalances.map((balance: TokenBalance) => ({
         ...balance,
         value: findAmount(updates, balance, 'price'),
         balance: findAmount(updates, balance, 'balance'),
       }))
 
-      dispatch({ data: tokenBalancesUpdates, type: RECEIVE_PORTFOLIO })
+      dispatch({ data: updatedTokenBalances, type: RECEIVE_PORTFOLIO })
     })
 
     watcher.start()

--- a/tinlake-ui/ducks/portfolio.ts
+++ b/tinlake-ui/ducks/portfolio.ts
@@ -73,7 +73,7 @@ export function loadPortfolio(
 
     const toBN = (val: BigNumber) => new BN(val.toString())
 
-    const watches = ipfsPools.active.flatMap((pool) => [
+    const watchers = ipfsPools.active.flatMap((pool) => [
       {
         target: pool.addresses.ASSESSOR,
         call: ['calcJuniorTokenPrice()(uint256)'],
@@ -96,7 +96,7 @@ export function loadPortfolio(
       },
     ])
 
-    const watcher = createWatcher(watches, multicallConfig)
+    const watcher = createWatcher(watchers, multicallConfig)
 
     /*
      * matches the token id's in tokenBalance with the token id's


### PR DESCRIPTION
### Description

This pull request implements the [`multicall.js`](https://github.com/makerdao/multicall.js) library for the `/portfolio` page in order to get real time data rather than just the daily updates from the subgraph.

I used `any[]` type on [here](https://github.com/centrifuge/apps/compare/use-multicall-on-portfolio#diff-0a9ef8b7e0d47f2972a9b22bf5c91b8a05e3e4cdec0f95c7f242c370ac075dbaR106) and [here](https://github.com/centrifuge/apps/compare/use-multicall-on-portfolio#diff-0a9ef8b7e0d47f2972a9b22bf5c91b8a05e3e4cdec0f95c7f242c370ac075dbaR120) because there seems to be a problem with the way that `multicall.js` ships their types. There is currently a [pull request](https://github.com/makerdao/multicall.js/pull/29) raised on the `multicall.js` repo to fix the issue.

[Staging Link](https://606f25b98533b600088856a2--tinlake-kovan-staging.netlify.app/)

Closes #113 