### PR TITLE
fix: hook use in thunk

### DIFF
--- a/.github/workflows/tinlake-ui-deploy-to-dev.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-dev.yml
@@ -38,7 +38,7 @@ jobs:
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}
 
       - name: Setup Node
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v2
         with:
           node-version: '12'
 

--- a/.github/workflows/tinlake-ui-deploy-to-prod.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-prod.yml
@@ -38,7 +38,7 @@ jobs:
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}
 
       - name: Setup Node
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v2
         with:
           node-version: '12'
 

--- a/.github/workflows/tinlake-ui-deploy-to-staging.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-staging.yml
@@ -38,7 +38,7 @@ jobs:
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}
 
       - name: Setup Node
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v2
         with:
           node-version: '12'
 
@@ -117,7 +117,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Setup Node
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v2
         with:
           node-version: '12'
 

--- a/tinlake-ui/components/Auth/index.tsx
+++ b/tinlake-ui/components/Auth/index.tsx
@@ -8,7 +8,7 @@ import WrongNetwork from '../WrongNetwork'
 
 interface Props {
   tinlake: ITinlake
-  render: (auth?: AuthState) => JSX.Element
+  render: (auth: AuthState) => JSX.Element
   auth?: AuthState
   load?: (tinlake: ITinlake, debugAddress: string | null) => Promise<void>
 }

--- a/tinlake-ui/components/Auth/index.tsx
+++ b/tinlake-ui/components/Auth/index.tsx
@@ -3,35 +3,28 @@ import * as React from 'react'
 import { connect } from 'react-redux'
 import config from '../../config'
 import { AuthState, load } from '../../ducks/auth'
+import { useQueryDebugEthAddress } from '../../utils/useQueryDebugEthAddress'
 import WrongNetwork from '../WrongNetwork'
 
 interface Props {
   tinlake: ITinlake
-  render: (auth: AuthState) => React.ReactElement | null | false
+  render: (auth?: AuthState) => JSX.Element
   auth?: AuthState
-  load?: (tinlake: ITinlake) => Promise<void>
+  load?: (tinlake: ITinlake, debugAddress: string | null) => Promise<void>
 }
 
-class Auth extends React.Component<Props> {
-  componentDidMount() {
-    this.init()
+const Auth = ({ auth, load, render, tinlake }: Props): JSX.Element => {
+  const debugAddress = useQueryDebugEthAddress()
+
+  React.useEffect(() => {
+    load!(tinlake, debugAddress)
+  }, [])
+
+  if (auth!.network !== config.network) {
+    return <WrongNetwork expected={config.network} actual={auth!.network} />
   }
 
-  init = async () => {
-    const { tinlake, load } = this.props
-
-    load!(tinlake)
-  }
-
-  render() {
-    const { auth } = this.props
-
-    if (auth!.network !== config.network) {
-      return <WrongNetwork expected={config.network} actual={auth!.network} />
-    }
-
-    return this.props.render(auth!)
-  }
+  return render(auth!)
 }
 
 export default connect((state) => state, { load })(Auth)

--- a/tinlake-ui/ducks/auth.ts
+++ b/tinlake-ui/ducks/auth.ts
@@ -9,7 +9,6 @@ import Apollo from '../services/apollo'
 import { getOnboard, initOnboard } from '../services/onboard'
 import { getTinlake } from '../services/tinlake'
 import { networkIdToName } from '../utils/networkNameResolver'
-import { useQueryDebugEthAddress } from '../utils/useQueryDebugEthAddress'
 
 // Actions
 const CLEAR = 'tinlake-ui/auth/CLEAR'
@@ -127,12 +126,13 @@ export default function reducer(state: AuthState = initialState, action: AnyActi
 // navigation event between pages, which discards the redux state, but does not discard onboard. Putting onboard into
 // the state would work, but it would lead to two sources of truth. Consequently, we keep onboard as an external
 // stateful API here and manually sync values over on load.
-export function load(tinlake: ITinlake): ThunkAction<Promise<void>, { auth: AuthState }, undefined, Action> {
+export function load(
+  tinlake: ITinlake,
+  debugAddress: string | null
+): ThunkAction<Promise<void>, { auth: AuthState }, undefined, Action> {
   return async (dispatch, getState) => {
     const { auth } = getState()
     let onboard = getOnboard()
-
-    const debugAddress = useQueryDebugEthAddress()
 
     // onboard is already initialized, only ensure values are correct and return
     if (onboard) {


### PR DESCRIPTION
Was getting this runtime error since `useQueryDebugEthAddress` was being used inside a `thunk` which goes against React's [rules of hooks](https://reactjs.org/docs/hooks-rules.html#only-call-hooks-from-react-functions) can only be used in function components.

<img src="https://user-images.githubusercontent.com/28536523/116609014-7b118180-a8f9-11eb-94ea-9ef07764fff1.png" width="500" />

I refactored to move the implementation to the `Auth` component which passes the hook's return data to the `thunk`.

Also slipped in a few ci tweaks 😉 
