### PR TITLE
feat: add AO rewards to investor rewards

### DIFF
--- a/tinlake-ui/components/PoolsMetrics/index.tsx
+++ b/tinlake-ui/components/PoolsMetrics/index.tsx
@@ -28,7 +28,16 @@ const PoolsMetrics: React.FC<Props> = (props: Props) => {
     dispatch(maybeLoadRewards())
   }, [])
 
-  const totalRewardsEarned = baseToDisplay(rewards.data?.toDateRewardAggregateValue || '0', 18)
+  const AORewardsEarned = rewards.data?.toDateAORewardAggregateValue
+  const investorRewardsEarned = rewards.data?.toDateRewardAggregateValue
+
+  const totalRewardsEarned = React.useMemo((): string => {
+    if (AORewardsEarned && investorRewardsEarned) {
+      return baseToDisplay(investorRewardsEarned.add(AORewardsEarned), 18)
+    }
+
+    return '0'
+  }, [AORewardsEarned, investorRewardsEarned])
 
   const maxPoolValue = Math.max.apply(
     Math,

--- a/tinlake-ui/ducks/rewards.ts
+++ b/tinlake-ui/ducks/rewards.ts
@@ -11,6 +11,7 @@ const RECEIVE_REWARDS = 'tinlake-ui/rewards/RECEIVE_REWARDS'
 
 export interface RewardsData {
   toDateRewardAggregateValue: BN
+  toDateAORewardAggregateValue: BN
   rewardRate: Decimal
   todayReward: BN
 }

--- a/tinlake-ui/services/apollo/index.ts
+++ b/tinlake-ui/services/apollo/index.ts
@@ -306,6 +306,7 @@ class Apollo {
             rewardDayTotals(first: 1, skip: 1, orderBy: id, orderDirection: desc) {
               rewardRate
               toDateRewardAggregateValue
+              toDateAORewardAggregateValue
               todayReward
             }
           }
@@ -322,6 +323,7 @@ class Apollo {
 
     return {
       toDateRewardAggregateValue: new BN(new Decimal(data.toDateRewardAggregateValue).toFixed(0)),
+      toDateAORewardAggregateValue: new BN(new Decimal(data.toDateAORewardAggregateValue).toFixed(0)),
       rewardRate: new Decimal(data.rewardRate),
       todayReward: new BN(new Decimal(data.todayReward).toFixed(0)),
     }


### PR DESCRIPTION
### Description

This pull requests adds the AO rewards to the investor rewards amount on the dashboard page.

**NOTE:** This functionality will not work on `Kovan` or `mainnet` until the latest version of the subgraph that contains the [toDateAORewardAggregateValue](https://github.com/centrifuge/tinlake-subgraph/blob/39558c47e892ac7b2825c6a051a9925567d59a04/schema.graphql#L187) property is deployed. Otherwise, the dashboard will render with `0.0000 CFG`:
![image](https://user-images.githubusercontent.com/28536523/118913534-43419c80-b8ef-11eb-93f2-625ff1703d4e.png)
