### PR TITLE
fix: docs link

### DIFF
--- a/tinlake-ui/components/TinlakeExplainer/index.tsx
+++ b/tinlake-ui/components/TinlakeExplainer/index.tsx
@@ -32,7 +32,7 @@ const TinlakeExplainer: React.FC = () => {
               <Button
                 primary
                 label="Read more about Tinlake"
-                href="https://centrifuge.io/products/tinlake/"
+                href="https://developer.centrifuge.io/learn/understanding-tinlake/"
                 target="_blank"
                 fill={false}
               />


### PR DESCRIPTION
### Description

This pull request updates the link on the `Read more about Tinlake` button under `Learn more` on the homepage.