### PR TITLE
feat: conditionally render "Close epoch" button

### DIFF
--- a/tinlake-ui/containers/Investment/View/EpochOverview.tsx
+++ b/tinlake-ui/containers/Investment/View/EpochOverview.tsx
@@ -23,7 +23,7 @@ interface Props extends TransactionProps {
 }
 
 const EpochOverview: React.FC<Props> = (props: Props) => {
-  const { query } = useRouter()
+  const router = useRouter()
 
   const pool = useSelector<any, PoolState>((state) => state.pool)
   const poolData = pool?.data as PoolData | undefined
@@ -47,23 +47,24 @@ const EpochOverview: React.FC<Props> = (props: Props) => {
 
   const [open, setOpen] = React.useState(false)
 
+  const showEpochButton = React.useMemo(
+    () => epochData && (poolData?.isPoolAdmin || router.query.show_close_epoch === 'true'),
+    [epochData, poolData, router.query]
+  )
+
   const EpochButton = React.useCallback(() => {
     switch (epochData?.state) {
       case 'can-be-closed':
-        if (poolData?.isPoolAdmin || query.show_close_epoch === 'true') {
-          return (
-            <Button
-              label="Close epoch"
-              primary
-              onClick={solve}
-              disabled={
-                disabled || epochData?.lastEpochClosed + epochData?.minimumEpochTime >= new Date().getTime() / 1000
-              }
-            />
-          )
-        }
-
-        return null
+        return (
+          <Button
+            label="Close epoch"
+            primary
+            onClick={solve}
+            disabled={
+              disabled || epochData?.lastEpochClosed + epochData?.minimumEpochTime >= new Date().getTime() / 1000
+            }
+          />
+        )
       case 'in-submission-period':
         return <Button label="Submit a solution" primary onClick={solve} />
       case 'in-challenge-period':
@@ -73,7 +74,7 @@ const EpochOverview: React.FC<Props> = (props: Props) => {
       default:
         return null
     }
-  }, [disabled, epochData, poolData, query])
+  }, [disabled, epochData, poolData, router.query])
 
   return (
     <Box background="#eee" pad={{ horizontal: '34px', bottom: 'xsmall' }} round="xsmall" margin={{ bottom: 'medium' }}>
@@ -287,7 +288,7 @@ const EpochOverview: React.FC<Props> = (props: Props) => {
               </TableBody>
             </Table>
 
-            {epochData && (
+            {showEpochButton && (
               <Box gap="small" justify="end" direction="row" margin={{ top: 'small' }}>
                 <EpochButton />
               </Box>

--- a/tinlake-ui/containers/Investment/View/EpochOverview.tsx
+++ b/tinlake-ui/containers/Investment/View/EpochOverview.tsx
@@ -2,6 +2,7 @@ import { baseToDisplay, ITinlake } from '@centrifuge/tinlake-js'
 import BN from 'bn.js'
 import { Box, Button, Heading, Table, TableBody, TableCell, TableRow } from 'grommet'
 import { FormDown } from 'grommet-icons'
+import { useRouter } from 'next/router'
 import * as React from 'react'
 import { connect, useSelector } from 'react-redux'
 import { LoadingValue } from '../../../components/LoadingValue/index'
@@ -22,6 +23,8 @@ interface Props extends TransactionProps {
 }
 
 const EpochOverview: React.FC<Props> = (props: Props) => {
+  const { query } = useRouter()
+
   const pool = useSelector<any, PoolState>((state) => state.pool)
   const poolData = pool?.data as PoolData | undefined
   const epochData = pool?.epoch as EpochData | undefined
@@ -43,6 +46,34 @@ const EpochOverview: React.FC<Props> = (props: Props) => {
   const investmentCapacity = poolData ? poolData.maxReserve.sub(poolData.reserve) : undefined
 
   const [open, setOpen] = React.useState(false)
+
+  const EpochButton = React.useCallback(() => {
+    switch (epochData?.state) {
+      case 'can-be-closed':
+        if (poolData?.isPoolAdmin || query.show_close_epoch === 'true') {
+          return (
+            <Button
+              label="Close epoch"
+              primary
+              onClick={solve}
+              disabled={
+                disabled || epochData?.lastEpochClosed + epochData?.minimumEpochTime >= new Date().getTime() / 1000
+              }
+            />
+          )
+        }
+
+        return null
+      case 'in-submission-period':
+        return <Button label="Submit a solution" primary onClick={solve} />
+      case 'in-challenge-period':
+        return <Button label={`Execute epoch ${epochData?.id}`} primary disabled />
+      case 'challenge-period-ended':
+        return <Button label={`Execute epoch ${epochData?.id}`} primary onClick={execute} disabled={disabled} />
+      default:
+        return null
+    }
+  }, [disabled, epochData, poolData, query])
 
   return (
     <Box background="#eee" pad={{ horizontal: '34px', bottom: 'xsmall' }} round="xsmall" margin={{ bottom: 'medium' }}>
@@ -258,26 +289,7 @@ const EpochOverview: React.FC<Props> = (props: Props) => {
 
             {epochData && (
               <Box gap="small" justify="end" direction="row" margin={{ top: 'small' }}>
-                {epochData?.state === 'can-be-closed' && (
-                  <Button
-                    label={`Close epoch`}
-                    primary
-                    onClick={solve}
-                    disabled={
-                      disabled ||
-                      epochData?.lastEpochClosed + epochData?.minimumEpochTime >= new Date().getTime() / 1000
-                    }
-                  />
-                )}
-                {epochData?.state === 'in-submission-period' && (
-                  <Button label={`Submit a solution`} primary onClick={solve} />
-                )}
-                {epochData?.state === 'in-challenge-period' && (
-                  <Button label={`Execute epoch ${epochData?.id}`} primary disabled={true} />
-                )}
-                {epochData?.state === 'challenge-period-ended' && (
-                  <Button label={`Execute epoch ${epochData?.id}`} primary onClick={execute} disabled={disabled} />
-                )}
+                <EpochButton />
               </Box>
             )}
           </Box>


### PR DESCRIPTION
### Description/

This pull request hides the `Close epoch` button on the investment page unless the user is either the pool admin or uses query params (`?show_close_epoch=true`) in the url.

[Preview link with query params](https://pr-249--dev-tinlake.netlify.app/pool/0x25dF507570c8285E9c8E7FFabC87db7836850dCd/new-silver-2/investments?show_close_epoch=true)

Addresses the `MUST HAVE`s of #235 