### PR TITLE
fix: properly update ui on closing epoch flow

### DIFF
--- a/tinlake-ui/containers/Investment/View/EpochOverview.tsx
+++ b/tinlake-ui/containers/Investment/View/EpochOverview.tsx
@@ -71,6 +71,8 @@ const EpochOverview: React.FC<Props> = (props: Props) => {
         return <Button label={`Execute epoch ${epochData?.id}`} primary disabled />
       case 'challenge-period-ended':
         return <Button label={`Execute epoch ${epochData?.id}`} primary onClick={execute} disabled={disabled} />
+      case 'open':
+        return <Button label="Close epoch" primary disabled />
       default:
         return null
     }

--- a/tinlake-ui/containers/Investment/View/index.tsx
+++ b/tinlake-ui/containers/Investment/View/index.tsx
@@ -25,10 +25,12 @@ const InvestmentsView: React.FC<Props> = (props: Props) => {
 
   const dispatch = useDispatch()
   const address = useSelector<any, string | null>((state) => state.auth.address)
+  const activeTransactions = useSelector<any, string | null>((state) => state.transactions.active)
+  const portfolioData = useSelector<any, string | null>((state) => state.portfolio.data)
 
   React.useEffect(() => {
-    dispatch(loadPool(props.tinlake))
-  }, [props.tinlake.signer, address])
+    dispatch(loadPool(props.tinlake, '', true))
+  }, [props.tinlake.signer, address, activeTransactions, portfolioData])
 
   return (
     <Box margin={{ top: 'medium' }}>


### PR DESCRIPTION
### Description

- Adds more dependencies to the `useEffect` that executes the `loadPool` `thunk` in order to refetch the pool when changes to the epoch flow are made
- Adds another `case` to the `EpochButton` component to show a `disabled` `Close epoch` `button` for when an epoch is `open`

Two caveats:
1. Sometimes it can take absurdly long to eventually rerender to the proper view like (5-10 seconds)
2. For the flow where closing the epoch is automatically executed, the UI does not properly rerender once the 5 minutes pass to go from `Lock DAI` -> `Epoch Executed`.

Closes #235 