### PR TITLE
fix: increase loans query amount to 1000

### DIFF
--- a/tinlake-ui/services/apollo/index.ts
+++ b/tinlake-ui/services/apollo/index.ts
@@ -258,7 +258,7 @@ class Apollo {
         {
           pools (where : {id: "${root.toLowerCase()}"}){
             id
-            loans {
+            loans (first: 1000) {
               id
               pool {
                 id


### PR DESCRIPTION
### Description

This pull request increases the query response from the default of 100 to an explicit 1000.

Closes #257 