### PR TITLE
always show pending transations

### DIFF
--- a/tinlake-ui/ducks/transactions.ts
+++ b/tinlake-ui/ducks/transactions.ts
@@ -150,7 +150,6 @@ export function processTransaction(
   return async (dispatch) => {
     const id = unconfirmedTx.id
     dispatch({ id, transaction: unconfirmedTx, type: SET_ACTIVE_TRANSACTION })
-    let hasCompleted = false
 
     // Start transaction
     const tinlake = initTinlake(unconfirmedTx.tinlakeConfig)
@@ -177,7 +176,6 @@ export function processTransaction(
         await dispatch({ id, transaction: pendingTx, dontChangeUpdatedAt: true, type: SET_ACTIVE_TRANSACTION })
 
         const receipt = await tinlake.getTransactionReceipt(tx)
-        hasCompleted = true
 
         const outcome = receipt.status === 1
         outcomeTx.status = outcome ? 'succeeded' : 'failed'
@@ -189,11 +187,9 @@ export function processTransaction(
         }
       } else if (tx.status === 1) {
         // Succeeded immediately
-        hasCompleted = true
         outcomeTx.status = 'succeeded'
       } else {
         // Failed or rejected
-        hasCompleted = true
         outcomeTx.status = 'failed'
         outcomeTx.failedReason = tx.error
         if (tx.transactionhash) {

--- a/tinlake-ui/ducks/transactions.ts
+++ b/tinlake-ui/ducks/transactions.ts
@@ -176,29 +176,6 @@ export function processTransaction(
         }
         await dispatch({ id, transaction: pendingTx, dontChangeUpdatedAt: true, type: SET_ACTIVE_TRANSACTION })
 
-        const pendingTxTimeout = 10000
-        const hidePendingTxCallback = async () => {
-          if (hasCompleted) return
-
-          if (!document.hidden) {
-            const hiddenPendingTx: Transaction = {
-              ...pendingTx,
-              showIfClosed: false,
-            }
-            await dispatch({
-              id,
-              transaction: hiddenPendingTx,
-              dontChangeUpdatedAt: true,
-              type: SET_ACTIVE_TRANSACTION,
-            })
-          } else {
-            setTimeout(hidePendingTxCallback, pendingTxTimeout)
-          }
-        }
-
-        // Hide pending tx after 10s
-        setTimeout(hidePendingTxCallback, pendingTxTimeout)
-
         const receipt = await tinlake.getTransactionReceipt(tx)
         hasCompleted = true
 


### PR DESCRIPTION
Don't hide pending transactions after a timeout, but keep them visible until they succeed or fail.
Closes #143 