### PR TITLE
fix: add warning messages for redemptions

### DIFF
--- a/tinlake-ui/containers/CentChainWalletDialog/index.tsx
+++ b/tinlake-ui/containers/CentChainWalletDialog/index.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 import Alert from '../../components/Alert'
 import { CentChainWalletState, connect } from '../../ducks/centChainWallet'
 import { usePolkadotExtensionInstalled } from '../../utils/usePolkadotExtensionInstalled'
+import { Warning } from '../Investment/View/styles'
 
 const HelpIcon = styled.img`
   height: 16px;
@@ -45,12 +46,11 @@ const CentChainWalletDialog: React.FC = () => {
         <br />
         Please first install the Polkadot Wallet extension to get started. Please reload this page after you have
         installed the extension.
-        <Alert type="info" margin={{ vertical: 'medium' }}>
-          <div>
-            <HelpIcon src="/static/help-circle.svg" />
-            <HelpText>To claim rewards, link your Centrifuge Chain account before redeeming your investment</HelpText>
-          </div>
-        </Alert>
+        <Warning>
+          <HelpIcon src="/static/help-circle.svg" />
+          <HelpText>To claim rewards, link your Centrifuge Chain account before redeeming your investment</HelpText>
+        </Warning>
+        <br />
         <Box direction="row" justify="end" margin={{ top: 'medium' }}>
           <Button
             primary={!clickedInstall}

--- a/tinlake-ui/containers/CentChainWalletDialog/index.tsx
+++ b/tinlake-ui/containers/CentChainWalletDialog/index.tsx
@@ -2,9 +2,21 @@ import { Anchor, Box, Button } from 'grommet'
 import { useRouter } from 'next/router'
 import * as React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
+import styled from 'styled-components'
 import Alert from '../../components/Alert'
 import { CentChainWalletState, connect } from '../../ducks/centChainWallet'
 import { usePolkadotExtensionInstalled } from '../../utils/usePolkadotExtensionInstalled'
+
+const HelpIcon = styled.img`
+  height: 16px;
+  width: 16px;
+  vertical-align: text-top;
+`
+
+const HelpText = styled.span`
+  padding-left: 6px;
+  font-weight: 800;
+`
 
 const CentChainWalletDialog: React.FC = () => {
   const polkadotExtensionInstalled = usePolkadotExtensionInstalled()
@@ -33,6 +45,12 @@ const CentChainWalletDialog: React.FC = () => {
         <br />
         Please first install the Polkadot Wallet extension to get started. Please reload this page after you have
         installed the extension.
+        <Alert type="info" margin={{ vertical: 'medium' }}>
+          <div>
+            <HelpIcon src="/static/help-circle.svg" />
+            <HelpText>To claim rewards, link your Centrifuge Chain account before redeeming your investment</HelpText>
+          </div>
+        </Alert>
         <Box direction="row" justify="end" margin={{ top: 'medium' }}>
           <Button
             primary={!clickedInstall}

--- a/tinlake-ui/containers/CentChainWalletDialog/index.tsx
+++ b/tinlake-ui/containers/CentChainWalletDialog/index.tsx
@@ -1,4 +1,5 @@
 import { Anchor, Box, Button } from 'grommet'
+import { CircleAlert } from 'grommet-icons'
 import { useRouter } from 'next/router'
 import * as React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
@@ -8,7 +9,7 @@ import { CentChainWalletState, connect } from '../../ducks/centChainWallet'
 import { usePolkadotExtensionInstalled } from '../../utils/usePolkadotExtensionInstalled'
 import { Warning } from '../Investment/View/styles'
 
-const HelpIcon = styled.img`
+const LinkingAlert = styled(CircleAlert)`
   height: 16px;
   width: 16px;
   vertical-align: text-top;
@@ -47,7 +48,7 @@ const CentChainWalletDialog: React.FC = () => {
         Please first install the Polkadot Wallet extension to get started. Please reload this page after you have
         installed the extension.
         <Warning>
-          <HelpIcon src="/static/help-circle.svg" />
+          <LinkingAlert />
           <HelpText>To claim rewards, link your Centrifuge Chain account before redeeming your investment</HelpText>
         </Warning>
         <br />

--- a/tinlake-ui/containers/Investment/View/RedeemCard.tsx
+++ b/tinlake-ui/containers/Investment/View/RedeemCard.tsx
@@ -3,6 +3,7 @@ import { baseToDisplay, ITinlake } from '@centrifuge/tinlake-js'
 import BN from 'bn.js'
 import { Decimal } from 'decimal.js-light'
 import { Box, Button, Heading } from 'grommet'
+import { CircleAlert } from 'grommet-icons'
 import * as React from 'react'
 import { connect, useSelector } from 'react-redux'
 import styled from 'styled-components'
@@ -12,8 +13,7 @@ import { addThousandsSeparators } from '../../../utils/addThousandsSeparators'
 import { Warning } from './styles'
 import { Card } from './TrancheOverview'
 
-const HelpIcon = styled.img`
-  font-weight: 800;
+const LinkingAlert = styled(CircleAlert)`
   height: 16px;
   width: 16px;
   vertical-align: text-top;
@@ -110,7 +110,7 @@ const RedeemCard: React.FC<Props> = (props: Props) => {
         disabled={disabled}
       />
       <Warning>
-        <HelpIcon src="/static/help-circle.svg" />
+        <LinkingAlert />
         <HelpTitle>No Centrifuge Chain Account Linked</HelpTitle>
         <HelpText>To claim rewards, link your Centrifuge Chain account before redeeming your investment</HelpText>
       </Warning>

--- a/tinlake-ui/containers/Investment/View/RedeemCard.tsx
+++ b/tinlake-ui/containers/Investment/View/RedeemCard.tsx
@@ -5,10 +5,29 @@ import { Decimal } from 'decimal.js-light'
 import { Box, Button, Heading } from 'grommet'
 import * as React from 'react'
 import { connect, useSelector } from 'react-redux'
+import styled from 'styled-components'
+import Alert from '../../../components/Alert'
 import { Pool } from '../../../config'
 import { createTransaction, TransactionProps, useTransactionState } from '../../../ducks/transactions'
 import { addThousandsSeparators } from '../../../utils/addThousandsSeparators'
 import { Card } from './TrancheOverview'
+
+const HelpIcon = styled.img`
+  font-weight: 800;
+  height: 16px;
+  width: 16px;
+  vertical-align: text-top;
+`
+
+const HelpTitle = styled.span`
+  margin-bottom: 20px;
+  padding-left: 6px;
+  font-weight: 800;
+`
+
+const HelpText = styled.div`
+  padding-top: 8px;
+`
 
 interface Props extends TransactionProps {
   selectedPool?: Pool
@@ -90,7 +109,13 @@ const RedeemCard: React.FC<Props> = (props: Props) => {
         onChange={onChange}
         disabled={disabled}
       />
-
+      <Alert type="info" margin={{ vertical: 'medium' }}>
+        <div>
+          <HelpIcon src="/static/help-circle.svg" />
+          <HelpTitle>No Centrifuge Chain Account Linked</HelpTitle>
+          <HelpText>To claim rewards, link your Centrifuge Chain account before redeeming your investment</HelpText>
+        </div>
+      </Alert>
       <Box gap="small" justify="end" direction="row" margin={{ top: 'medium' }}>
         <Button label="Cancel" onClick={() => props.setCard('home')} disabled={disabled} />
         <Button primary label={'Redeem'} onClick={submit} disabled={error !== undefined || disabled} />

--- a/tinlake-ui/containers/Investment/View/RedeemCard.tsx
+++ b/tinlake-ui/containers/Investment/View/RedeemCard.tsx
@@ -6,10 +6,10 @@ import { Box, Button, Heading } from 'grommet'
 import * as React from 'react'
 import { connect, useSelector } from 'react-redux'
 import styled from 'styled-components'
-import Alert from '../../../components/Alert'
 import { Pool } from '../../../config'
 import { createTransaction, TransactionProps, useTransactionState } from '../../../ducks/transactions'
 import { addThousandsSeparators } from '../../../utils/addThousandsSeparators'
+import { Warning } from './styles'
 import { Card } from './TrancheOverview'
 
 const HelpIcon = styled.img`
@@ -109,13 +109,11 @@ const RedeemCard: React.FC<Props> = (props: Props) => {
         onChange={onChange}
         disabled={disabled}
       />
-      <Alert type="info" margin={{ vertical: 'medium' }}>
-        <div>
-          <HelpIcon src="/static/help-circle.svg" />
-          <HelpTitle>No Centrifuge Chain Account Linked</HelpTitle>
-          <HelpText>To claim rewards, link your Centrifuge Chain account before redeeming your investment</HelpText>
-        </div>
-      </Alert>
+      <Warning>
+        <HelpIcon src="/static/help-circle.svg" />
+        <HelpTitle>No Centrifuge Chain Account Linked</HelpTitle>
+        <HelpText>To claim rewards, link your Centrifuge Chain account before redeeming your investment</HelpText>
+      </Warning>
       <Box gap="small" justify="end" direction="row" margin={{ top: 'medium' }}>
         <Button label="Cancel" onClick={() => props.setCard('home')} disabled={disabled} />
         <Button primary label={'Redeem'} onClick={submit} disabled={error !== undefined || disabled} />

--- a/tinlake-ui/containers/SetCentAccount/index.tsx
+++ b/tinlake-ui/containers/SetCentAccount/index.tsx
@@ -4,7 +4,6 @@ import { Box, Button, Select } from 'grommet'
 import * as React from 'react'
 import { connect, useDispatch, useSelector } from 'react-redux'
 import styled from 'styled-components'
-import Alert from '../../components/Alert'
 import { AuthState } from '../../ducks/auth'
 import { CentChainWalletState, InjectedAccount } from '../../ducks/centChainWallet'
 import { createTransaction, TransactionProps, useTransactionState } from '../../ducks/transactions'
@@ -13,6 +12,7 @@ import { accountIdToCentChainAddr } from '../../services/centChain/accountIdToCe
 import { centChainAddrToAccountId } from '../../services/centChain/centChainAddrToAccountId'
 import { isCentChainAddr } from '../../services/centChain/isCentChainAddr'
 import { shortAddr } from '../../utils/shortAddr'
+import { Warning } from '../Investment/View/styles'
 
 const HelpIcon = styled.img`
   height: 16px;
@@ -121,12 +121,10 @@ const SetCentAccount: React.FC<Props> = ({ createTransaction, tinlake }: Props) 
     <div>
       Select the Centrifuge Chain account you want to link to your Ethereum account below. Note: To claim rewards, link
       your Centrifuge Chain account before redeeming your investment.
-      <Alert type="info" margin={{ vertical: 'medium' }}>
-        <div>
-          <HelpIcon src="/static/help-circle.svg" />
-          <HelpText>Make sure to select the correct account – linking the account cannot be undone</HelpText>
-        </div>
-      </Alert>
+      <Warning>
+        <HelpIcon src="/static/help-circle.svg" />
+        <HelpText>Make sure to select the correct account – linking the account cannot be undone</HelpText>
+      </Warning>
       <div>
         <Select
           options={cWallet.accounts}

--- a/tinlake-ui/containers/SetCentAccount/index.tsx
+++ b/tinlake-ui/containers/SetCentAccount/index.tsx
@@ -25,6 +25,10 @@ const HelpText = styled.span`
   font-weight: 800;
 `
 
+const LinkingWarning = styled(Warning)`
+  margin-bottom: 16px;
+`
+
 interface Props extends TransactionProps {
   tinlake: ITinlake
 }
@@ -121,10 +125,10 @@ const SetCentAccount: React.FC<Props> = ({ createTransaction, tinlake }: Props) 
     <div>
       Select the Centrifuge Chain account you want to link to your Ethereum account below. Note: To claim rewards, link
       your Centrifuge Chain account before redeeming your investment.
-      <Warning>
+      <LinkingWarning>
         <HelpIcon src="/static/help-circle.svg" />
         <HelpText>Make sure to select the correct account – linking the account cannot be undone</HelpText>
-      </Warning>
+      </LinkingWarning>
       <div>
         <Select
           options={cWallet.accounts}

--- a/tinlake-ui/containers/SetCentAccount/index.tsx
+++ b/tinlake-ui/containers/SetCentAccount/index.tsx
@@ -4,6 +4,7 @@ import { Box, Button, Select } from 'grommet'
 import * as React from 'react'
 import { connect, useDispatch, useSelector } from 'react-redux'
 import styled from 'styled-components'
+import Alert from '../../components/Alert'
 import { AuthState } from '../../ducks/auth'
 import { CentChainWalletState, InjectedAccount } from '../../ducks/centChainWallet'
 import { createTransaction, TransactionProps, useTransactionState } from '../../ducks/transactions'
@@ -12,6 +13,17 @@ import { accountIdToCentChainAddr } from '../../services/centChain/accountIdToCe
 import { centChainAddrToAccountId } from '../../services/centChain/centChainAddrToAccountId'
 import { isCentChainAddr } from '../../services/centChain/isCentChainAddr'
 import { shortAddr } from '../../utils/shortAddr'
+
+const HelpIcon = styled.img`
+  height: 16px;
+  width: 16px;
+  vertical-align: text-top;
+`
+
+const HelpText = styled.span`
+  padding-left: 6px;
+  font-weight: 800;
+`
 
 interface Props extends TransactionProps {
   tinlake: ITinlake
@@ -107,10 +119,14 @@ const SetCentAccount: React.FC<Props> = ({ createTransaction, tinlake }: Props) 
 
   return (
     <div>
-      Select the Centrifuge Chain account you want to link to your Ethereum account below.{' '}
-      <strong>This step cannot be undone. Please make sure to link the correct account.</strong>
-      <br />
-      <br />
+      Select the Centrifuge Chain account you want to link to your Ethereum account below. Note: To claim rewards, link
+      your Centrifuge Chain account before redeeming your investment.
+      <Alert type="info" margin={{ vertical: 'medium' }}>
+        <div>
+          <HelpIcon src="/static/help-circle.svg" />
+          <HelpText>Make sure to select the correct account – linking the account cannot be undone</HelpText>
+        </div>
+      </Alert>
       <div>
         <Select
           options={cWallet.accounts}

--- a/tinlake-ui/containers/SetCentAccount/index.tsx
+++ b/tinlake-ui/containers/SetCentAccount/index.tsx
@@ -1,6 +1,7 @@
 import { Tooltip } from '@centrifuge/axis-tooltip'
 import { ITinlake } from '@centrifuge/tinlake-js'
 import { Box, Button, Select } from 'grommet'
+import { CircleAlert } from 'grommet-icons'
 import * as React from 'react'
 import { connect, useDispatch, useSelector } from 'react-redux'
 import styled from 'styled-components'
@@ -14,7 +15,7 @@ import { isCentChainAddr } from '../../services/centChain/isCentChainAddr'
 import { shortAddr } from '../../utils/shortAddr'
 import { Warning } from '../Investment/View/styles'
 
-const HelpIcon = styled.img`
+const LinkingAlert = styled(CircleAlert)`
   height: 16px;
   width: 16px;
   vertical-align: text-top;
@@ -126,7 +127,7 @@ const SetCentAccount: React.FC<Props> = ({ createTransaction, tinlake }: Props) 
       Select the Centrifuge Chain account you want to link to your Ethereum account below. Note: To claim rewards, link
       your Centrifuge Chain account before redeeming your investment.
       <LinkingWarning>
-        <HelpIcon src="/static/help-circle.svg" />
+        <LinkingAlert />
         <HelpText>Make sure to select the correct account – linking the account cannot be undone</HelpText>
       </LinkingWarning>
       <div>


### PR DESCRIPTION
### Description

This pull request adds warning messages for investors that are redeeming before linking their cent chain addresses.

The info blocks do not have the yellow background with the full-width style because I used the `Alert` component that is already used throughout the app. If we want to change the alert style, we should probably do it for all alerts to remain consistent.

Closes #254 