### PR TITLE
Asset tab UI tweaks

### DIFF
--- a/tinlake-ui/containers/Loan/Borrow/index.tsx
+++ b/tinlake-ui/containers/Loan/Borrow/index.tsx
@@ -141,18 +141,16 @@ const LoanBorrow: React.FC<Props> = (props: Props) => {
       </Box>
       <Box align="start">
         <Box direction="row" gap="small">
-          <Button
-            onClick={borrow}
-            primary
-            label="Finance Asset"
-            disabled={
-              error !== undefined ||
-              new BN(borrowAmount).isZero() ||
-              !borrowEnabled ||
-              status === 'unconfirmed' ||
-              status === 'pending'
-            }
-          />
+          {props.pool?.epoch && borrowEnabled && (
+            <Button
+              onClick={borrow}
+              primary
+              label="Finance Asset"
+              disabled={
+                new BN(borrowAmount).isZero() || error !== undefined || status === 'unconfirmed' || status === 'pending'
+              }
+            />
+          )}
           {props.loan.status === 'NFT locked' && (
             <Button
               onClick={close}

--- a/tinlake-ui/containers/Loan/Issue/index.tsx
+++ b/tinlake-ui/containers/Loan/Issue/index.tsx
@@ -1,9 +1,10 @@
 import { NFT } from '@centrifuge/tinlake-js'
-import { Box, Button, FormField, TextInput } from 'grommet'
+import { Anchor, Box, Button, FormField, TextInput } from 'grommet'
 import * as React from 'react'
 import { connect } from 'react-redux'
 import Alert from '../../../components/Alert'
 import NftData from '../../../components/NftData'
+import { PoolLink } from '../../../components/PoolLink'
 import { Pool } from '../../../config'
 import { AuthState, ensureAuthed, loadProxies } from '../../../ducks/auth'
 import { createTransaction, TransactionProps, useTransactionState } from '../../../ducks/transactions'
@@ -92,6 +93,17 @@ const IssueLoan: React.FC<Props> = (props: Props) => {
 
   return (
     <Box>
+      {status === 'succeeded' && (
+        <Alert pad={{ horizontal: 'medium' }} margin={{ bottom: 'medium' }} type="success">
+          <p>
+            Your NFT is succesfully locked. Please proceed to the{' '}
+            <PoolLink href={{ pathname: '/assets' }}>
+              <Anchor>Asset List</Anchor>
+            </PoolLink>{' '}
+            to finance this NFT.
+          </p>
+        </Alert>
+      )}
       <Box pad="medium" elevation="small" round="xsmall" background="white">
         <Box>
           <Box direction="row" gap="medium" margin={{ top: 'medium' }}>

--- a/tinlake-ui/containers/Loan/Repay/index.tsx
+++ b/tinlake-ui/containers/Loan/Repay/index.tsx
@@ -118,18 +118,16 @@ const LoanRepay: React.FC<Props> = (props: Props) => {
         />
       </Box>
       <Box align="start">
-        <Button
-          onClick={repay}
-          primary
-          label="Repay"
-          disabled={
-            !hasDebt ||
-            new BN(repayAmount).isZero() ||
-            error !== undefined ||
-            status === 'unconfirmed' ||
-            status === 'pending'
-          }
-        />
+        {hasDebt && (
+          <Button
+            onClick={repay}
+            primary
+            label="Repay"
+            disabled={
+              new BN(repayAmount).isZero() || error !== undefined || status === 'unconfirmed' || status === 'pending'
+            }
+          />
+        )}
       </Box>
     </Box>
   )


### PR DESCRIPTION
Fixes (i), (ii) and (iii) of #144 

(i) Show "Lock NFT" button only when account is pool admin, has a proxy, or `lockNFT` query param is set.
(ii) Adds success feedback for locking NFT
(iii) Hide "Repay" button when you can borrow, hide "Finance" button when you can't.

Closes #109 