### PR TITLE
Prevent borrower from Locking NFT that is not in his wallet

### DIFF
--- a/tinlake-ui/containers/Loan/Issue/index.tsx
+++ b/tinlake-ui/containers/Loan/Issue/index.tsx
@@ -7,7 +7,7 @@ import Alert from '../../../components/Alert'
 import NftData from '../../../components/NftData'
 import { PoolLink } from '../../../components/PoolLink'
 import { Pool } from '../../../config'
-import { AuthState, ensureAuthed, loadProxies } from '../../../ducks/auth'
+import { AuthState, ensureAuthed } from '../../../ducks/auth'
 import { createTransaction, TransactionProps, useTransactionState } from '../../../ducks/transactions'
 import { getNFT as getNFTAction } from '../../../services/tinlake/actions'
 import LoanView from '../View'
@@ -16,7 +16,6 @@ interface Props extends TransactionProps {
   tinlake: any
   poolConfig: Pool
   auth: AuthState
-  loadProxies?: () => Promise<void>
   ensureAuthed?: () => Promise<void>
 }
 
@@ -45,14 +44,12 @@ const IssueLoan: React.FC<Props> = (props: Props) => {
   }
 
   const getNFT = async (currentRegistry: string, currentTokenId: string) => {
-    console.log('getnft', currentRegistry, currentTokenId)
     if (currentTokenId && currentTokenId.length > 0) {
       setNft(null)
       setNftError('')
       const promise = getNFTAction(currentRegistry, props.tinlake, currentTokenId)
       inFlight.current = promise
       const result = await promise
-      console.log('result', result)
       const { nft, error } = result as Partial<{ tokenId: string; nft: NFT; error: string }>
       if (inFlight.current !== promise) {
         return
@@ -80,10 +77,8 @@ const IssueLoan: React.FC<Props> = (props: Props) => {
 
   React.useEffect(() => {
     if (status === 'succeeded') {
-      console.log('result', result)
       const loanId = result.data
       setLoanId(loanId)
-      props.loadProxies && props.loadProxies()
     }
   }, [status])
 
@@ -160,4 +155,4 @@ const IssueLoan: React.FC<Props> = (props: Props) => {
   )
 }
 
-export default connect((state) => state, { loadProxies, ensureAuthed, createTransaction })(IssueLoan)
+export default connect((state) => state, { ensureAuthed, createTransaction })(IssueLoan)

--- a/tinlake-ui/containers/Loan/Issue/index.tsx
+++ b/tinlake-ui/containers/Loan/Issue/index.tsx
@@ -140,7 +140,7 @@ const IssueLoan: React.FC<Props> = (props: Props) => {
         </Box>
 
         {nftError && <Alert type="error">{nftError}</Alert>}
-        {!disabled && wrongOwner && <Alert type="error">NFT isn't owned by connected address</Alert>}
+        {!disabled && wrongOwner && <Alert type="error">NFT not held in your wallet</Alert>}
       </Box>
 
       {loanId ? (

--- a/tinlake-ui/pages/pool/[root]/[slug]/assets/issue.tsx
+++ b/tinlake-ui/pages/pool/[root]/[slug]/assets/issue.tsx
@@ -1,6 +1,6 @@
 import { Box } from 'grommet'
 import { GetStaticProps } from 'next'
-import withRouter, { WithRouterProps } from 'next/dist/client/with-router'
+import { WithRouterProps } from 'next/dist/client/with-router'
 import Head from 'next/head'
 import * as React from 'react'
 import Auth from '../../../../../components/Auth'
@@ -22,7 +22,6 @@ interface Props extends WithRouterProps {
 class LoanIssuePage extends React.Component<Props> {
   render() {
     const { pool, ipfsPools } = this.props
-    const { tokenId, registry }: { tokenId: string; registry: string } = this.props.router.query as any
 
     return (
       <WithFooter>
@@ -48,13 +47,7 @@ class LoanIssuePage extends React.Component<Props> {
                       <Box margin={{ top: 'medium' }}>
                         <PageTitle pool={pool} page={`Lock NFT`} parentPage="Assets" parentPageHref="/assets" />
 
-                        <IssueLoan
-                          tinlake={tinlake}
-                          poolConfig={pool}
-                          auth={auth}
-                          tokenId={tokenId}
-                          registry={registry}
-                        />
+                        <IssueLoan tinlake={tinlake} poolConfig={pool} auth={auth} />
                       </Box>
                     )}
                   />
@@ -90,4 +83,4 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   }
 }
 
-export default withRouter(LoanIssuePage)
+export default LoanIssuePage

--- a/tinlake-ui/services/tinlake/actions.ts
+++ b/tinlake-ui/services/tinlake/actions.ts
@@ -51,7 +51,7 @@ export async function getNFT(registry: string, tinlake: ITinlake, tokenId: strin
   }
 
   if (!nftOwner) {
-    return loggedError({}, 'Could not get NFT owner for NFT ID', tokenId)
+    return loggedError({}, 'Could not get NFT owner', tokenId)
   }
 
   try {

--- a/tinlake-ui/services/tinlake/actions.ts
+++ b/tinlake-ui/services/tinlake/actions.ts
@@ -670,8 +670,8 @@ function loggedError(error: any, message: string, id: string): PendingTransactio
   console.error(`${message} ${id}`, error)
   // TODO: same as line 549
   return {
+    id,
     status: 0,
     error: message,
-    id,
   } as any
 }


### PR DESCRIPTION
Disabled the Lock NFT button when the owner of the NFT isn't the connected address.
Also fixes the error messages that were not being displayed.

Closes #67 