### PR TITLE
Fix loan status bug if NFT is locked again

### DIFF
--- a/tinlake-ui/ducks/loans.ts
+++ b/tinlake-ui/ducks/loans.ts
@@ -214,13 +214,13 @@ export function loadLoan(
         data.ownerOf = await tinlake.getOwnerOfLoan(loanId)
 
         // TODO: load getOwnerOfCollateral using multicall
-        if (
+        if (data.ownerOf === ZERO_ADDRESS) {
+          data.status = 'closed'
+        } else if (
           (await tinlake.getOwnerOfCollateral(data.registry, data.tokenId)).toString() ===
           tinlake.contractAddresses.SHELF
         ) {
           data.status = 'ongoing'
-        } else if (data.ownerOf === ZERO_ADDRESS) {
-          data.status = 'closed'
         } else {
           data.status = 'NFT locked'
         }


### PR DESCRIPTION
Checks if loan NFT is burned before checking if the collateral NFT is in the SHELF contract

Closes #253 