### PR TITLE
Gateway: fix incorrect date in date input

### DIFF
--- a/gateway/packages/ui/src/documents/AttributeField.tsx
+++ b/gateway/packages/ui/src/documents/AttributeField.tsx
@@ -2,7 +2,7 @@ import { DateInput } from '@centrifuge/axis-date-input'
 import { NumberInput } from '@centrifuge/axis-number-input'
 import { Document } from '@centrifuge/gateway-lib/models/document'
 import { Attribute, AttrTypes } from '@centrifuge/gateway-lib/models/schema'
-import { dateToString, extractDate, getPercentFormat } from '@centrifuge/gateway-lib/utils/formaters'
+import { dateToString, getPercentFormat } from '@centrifuge/gateway-lib/utils/formaters'
 import { connect, FormikContext } from 'formik'
 import { Box, FormField, Select, TextInput } from 'grommet'
 import { get } from 'lodash'
@@ -91,7 +91,7 @@ export const AttributeField: FunctionComponent<Props> = (props: Props) => {
               return (
                 <DateInput
                   {...commonProps}
-                  value={extractDate(get(values, key))}
+                  value={get(values, key)}
                   onChange={(date) => {
                     setFieldValue(`${key}`, dateToString(date))
                   }}


### PR DESCRIPTION
Now leaves timezone info intact when passing the date