### PR TITLE
chore(tinlake-ui): change copy icon

### DIFF
--- a/tinlake-ui/package.json
+++ b/tinlake-ui/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/centrifuge/tinlake-ui#readme",
   "dependencies": {
-    "@centrifuge/axis-display-field": "0.4.2-develop.109",
+    "@centrifuge/axis-display-field": "0.4.2-develop.7a59cce.142+7a59cce",
     "@centrifuge/axis-modal": "0.1.1-develop.57",
     "@centrifuge/axis-ratio-bar": "0.4.2-develop.137",
     "@centrifuge/axis-spinner": "0.4.2-develop.109",

--- a/tinlake-ui/static/wallet/copy.svg
+++ b/tinlake-ui/static/wallet/copy.svg
@@ -1,4 +1,4 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M20 9H11C9.89543 9 9 9.89543 9 11V20C9 21.1046 9.89543 22 11 22H20C21.1046 22 22 21.1046 22 20V11C22 9.89543 21.1046 9 20 9Z" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M5 15H4C3.46957 15 2.96086 14.7893 2.58579 14.4142C2.21071 14.0391 2 13.5304 2 13V4C2 3.46957 2.21071 2.96086 2.58579 2.58579C2.96086 2.21071 3.46957 2 4 2H13C13.5304 2 14.0391 2.21071 14.4142 2.58579C14.7893 2.96086 15 3.46957 15 4V5" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5 15H4C3.46957 15 2.96086 14.7893 2.58579 14.4142C2.21071 14.0391 2 13.5304 2 13V4C2 3.46957 2.21071 2.96086 2.58579 2.58579C2.96086 2.21071 3.46957 2 4 2H13C13.5304 2 14.0391 2.21071 14.4142 2.58579C14.7893 2.96086 15 3.46957 15 4V5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2 2"/>
 </svg>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2233,16 +2233,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@centrifuge/axis-display-field@npm:0.4.2-develop.109":
-  version: 0.4.2-develop.109
-  resolution: "@centrifuge/axis-display-field@npm:0.4.2-develop.109"
+"@centrifuge/axis-display-field@npm:0.4.2-develop.7a59cce.142+7a59cce":
+  version: 0.4.2-develop.7a59cce.142
+  resolution: "@centrifuge/axis-display-field@npm:0.4.2-develop.7a59cce.142"
   peerDependencies:
     "@centrifuge/axis-utils": ">= 0.x"
     grommet: 2.7.x
     react: ">= 16.6.1"
     react-dom: ">= 16.6.1"
     styled-components: ">= 4.x"
-  checksum: bcf7ffd016ab8a2749e99f5e241c2f27ab5486e38797e634d9a0c774448c1b7c2c1c0f00bdd1c8fb450c699832a3df44100a02f77f3579354f3b5fbcd7233912
+  checksum: ced943c4fb5102bb490c6b5025e49772cc97bb6538cd6ddcd183e54d099264557565fca3e60f21bf0c19b7cea9e806537511cc5bc325f67bdce966eff6271031
   languageName: node
   linkType: hard
 
@@ -2768,7 +2768,7 @@ __metadata:
   dependencies:
     "@babel/plugin-transform-runtime": 7.10.5
     "@babel/preset-typescript": 7.10.4
-    "@centrifuge/axis-display-field": 0.4.2-develop.109
+    "@centrifuge/axis-display-field": 0.4.2-develop.7a59cce.142+7a59cce
     "@centrifuge/axis-modal": 0.1.1-develop.57
     "@centrifuge/axis-ratio-bar": 0.4.2-develop.137
     "@centrifuge/axis-spinner": 0.4.2-develop.109


### PR DESCRIPTION
Contributes to https://github.com/centrifuge/apps/issues/363

## Before (inconsistent copy icons)

![Screenshot 2021-09-08 at 16 43 57](https://user-images.githubusercontent.com/8630331/132532121-32068015-e7f4-47a0-afd4-27857af5a11b.png)

## After (consistent icons)

![Screenshot 2021-09-08 at 16 47 18](https://user-images.githubusercontent.com/8630331/132532179-f0eb0a54-2ed2-4c1f-9b8f-eb3fe2211377.png)
