### PR TITLE
ci: deploy pr to mainnet

### DIFF
--- a/.github/workflows/tinlake-ui-deploy-to-dev.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-dev.yml
@@ -67,7 +67,7 @@ jobs:
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify
-        uses: nwtgck/actions-netlify@v1.1
+        uses: nwtgck/actions-netlify@v1.2.0
         with:
           deploy-message: ${{ github.event.head_commit.message }}
           enable-commit-comment: false
@@ -139,7 +139,7 @@ jobs:
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify
-        uses: nwtgck/actions-netlify@v1.1
+        uses: nwtgck/actions-netlify@v1.2.0
         with:
           deploy-message: ${{ github.event.head_commit.message }}
           enable-commit-comment: false

--- a/.github/workflows/tinlake-ui-deploy-to-dev.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-dev.yml
@@ -8,7 +8,7 @@ on:
       - '.github/workflows/tinlake-ui-deploy-to-dev.yml'
 
 jobs:
-  build-and-deploy:
+  build-and-deploy-to-kovan:
     runs-on: ubuntu-latest
 
     defaults:
@@ -78,4 +78,76 @@ jobs:
           publish-dir: ./tinlake-ui/out
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN  }}
-          NETLIFY_SITE_ID: ${{ secrets.TINLAKE_UI_DEV_NETLIFY_SITE_ID }}
+          NETLIFY_SITE_ID: ${{ secrets.TINLAKE_UI_KOVAN_DEV_NETLIFY_SITE_ID }}
+
+  build-and-deploy-to-mainnet:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: tinlake-ui
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+
+      - name: Restore Yarn Workspaces
+        id: yarn-cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            **/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install Dependencies
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn install
+
+      - name: Cache Next.js Bundle
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/tinlake-ui/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Build
+        run: yarn export
+        env:
+          NEXT_PUBLIC_CENTRIFUGE_CHAIN_URL: 'wss://fullnode.centrifuge.io'
+          NEXT_PUBLIC_CLAIM_CFG_CONTRACT_ADDRESS: '0x1cA3B2E7FfCAF83d9228a64e4726402B1d5CC054'
+          NEXT_PUBLIC_ENV: 'PROD'
+          NEXT_PUBLIC_ETHERSCAN_URL: 'https://etherscan.io'
+          NEXT_PUBLIC_FEATURE_FLAG_NEW_ONBOARDING: '0x4B6CA198d257D755A5275648D471FE09931b764A,0xdB3bC9fB1893222d266762e9fF857EB74D75c7D6,0xfc2950dD337ca8496C18dfc0256Fb905A7E7E5c6,0x53b2d22d07E069a3b132BfeaaD275b10273d381E,0x0CED6166873038Ac0cc688e7E6d19E2cBE251Bf0,0x4cA805cE8EcE2E63FfC1F9f8F2731D3F48DF89Df,0x82B8617A16e388256617FeBBa1826093401a3fE5,0x560Ac248ce28972083B718778EEb0dbC2DE55740,0x3d167bd08f762FD391694c67B5e6aF0868c45538'
+          NEXT_PUBLIC_INFURA_KEY: ${{ secrets.NEXT_PUBLIC_INFURA_KEY }}
+          NEXT_PUBLIC_IPFS_GATEWAY: 'https://cloudflare-ipfs.com/ipfs/'
+          NEXT_PUBLIC_MULTICALL_CONTRACT_ADDRESS: '0xeefba1e63905ef1d7acba5a8513c70307c1ce441'
+          NEXT_PUBLIC_ONBOARD_API_HOST: 'https://onboard-api.centrifuge.io/'
+          NEXT_PUBLIC_POOL_REGISTRY: '0xddf1c516cf87126c6c610b52fd8d609e67fb6033'
+          NEXT_PUBLIC_POOLS_CONFIG: 'mainnetProduction'
+          NEXT_PUBLIC_POOLS_IPFS_HASH_OVERRIDE: 'QmZEh2BmAeRmwpE8NqcjDr42n3mxxJRfAvGGcGY2mESz2r'
+          NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
+          NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
+          NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://thegraph.centrifuge.io/subgraphs/name/centrifuge/tinlake-rewards'
+          NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
+
+      - name: Deploy To Netlify
+        uses: nwtgck/actions-netlify@v1.1
+        with:
+          deploy-message: ${{ github.event.head_commit.message }}
+          enable-commit-comment: false
+          functions-dir: ./tinlake-ui/functions
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          netlify-config-path: ./tinlake-ui/netlify.toml
+          production-deploy: true
+          publish-dir: ./tinlake-ui/out
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN  }}
+          NETLIFY_SITE_ID: ${{ secrets.TINLAKE_UI_MAINNET_DEV_NETLIFY_SITE_ID }}

--- a/.github/workflows/tinlake-ui-deploy-to-prod.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-prod.yml
@@ -64,7 +64,7 @@ jobs:
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify
-        uses: nwtgck/actions-netlify@v1.1
+        uses: nwtgck/actions-netlify@v1.2.0
         with:
           deploy-message: ${{ github.event.head_commit.message }}
           enable-commit-comment: false

--- a/.github/workflows/tinlake-ui-deploy-to-staging.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-staging.yml
@@ -64,7 +64,7 @@ jobs:
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify
-        uses: nwtgck/actions-netlify@v1.1
+        uses: nwtgck/actions-netlify@v1.2.0
         with:
           deploy-message: ${{ github.event.head_commit.message }}
           enable-commit-comment: false
@@ -136,7 +136,7 @@ jobs:
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify
-        uses: nwtgck/actions-netlify@v1.1
+        uses: nwtgck/actions-netlify@v1.2.0
         with:
           deploy-message: ${{ github.event.head_commit.message }}
           enable-commit-comment: false

--- a/.github/workflows/tinlake-ui-pull-request.yml
+++ b/.github/workflows/tinlake-ui-pull-request.yml
@@ -6,7 +6,7 @@ on:
       - '.github/workflows/tinlake-ui-pull-request.yml'
 
 jobs:
-  build-and-deploy:
+  build-and-deploy-to-kovan:
     runs-on: ubuntu-latest
 
     defaults:
@@ -76,4 +76,76 @@ jobs:
           publish-dir: ./tinlake-ui/out
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN  }}
-          NETLIFY_SITE_ID: ${{ secrets.TINLAKE_UI_DEV_NETLIFY_SITE_ID }}
+          NETLIFY_SITE_ID: ${{ secrets.TINLAKE_UI_KOVAN_DEV_NETLIFY_SITE_ID }}
+
+  build-and-deploy-to-mainnet:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: tinlake-ui
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+
+      - name: Restore Yarn Workspaces
+        id: yarn-cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            **/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install Dependencies
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn install
+
+      - name: Cache Next.js Bundle
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/tinlake-ui/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Build
+        run: yarn export
+        env:
+          NEXT_PUBLIC_CENTRIFUGE_CHAIN_URL: 'wss://fullnode.centrifuge.io'
+          NEXT_PUBLIC_CLAIM_CFG_CONTRACT_ADDRESS: '0x1cA3B2E7FfCAF83d9228a64e4726402B1d5CC054'
+          NEXT_PUBLIC_ENV: 'PROD'
+          NEXT_PUBLIC_ETHERSCAN_URL: 'https://etherscan.io'
+          NEXT_PUBLIC_FEATURE_FLAG_NEW_ONBOARDING: '0x4B6CA198d257D755A5275648D471FE09931b764A,0xdB3bC9fB1893222d266762e9fF857EB74D75c7D6,0xfc2950dD337ca8496C18dfc0256Fb905A7E7E5c6,0x53b2d22d07E069a3b132BfeaaD275b10273d381E,0x0CED6166873038Ac0cc688e7E6d19E2cBE251Bf0,0x4cA805cE8EcE2E63FfC1F9f8F2731D3F48DF89Df,0x82B8617A16e388256617FeBBa1826093401a3fE5,0x560Ac248ce28972083B718778EEb0dbC2DE55740,0x3d167bd08f762FD391694c67B5e6aF0868c45538'
+          NEXT_PUBLIC_INFURA_KEY: ${{ secrets.NEXT_PUBLIC_INFURA_KEY }}
+          NEXT_PUBLIC_IPFS_GATEWAY: 'https://cloudflare-ipfs.com/ipfs/'
+          NEXT_PUBLIC_MULTICALL_CONTRACT_ADDRESS: '0xeefba1e63905ef1d7acba5a8513c70307c1ce441'
+          NEXT_PUBLIC_ONBOARD_API_HOST: 'https://onboard-api.centrifuge.io/'
+          NEXT_PUBLIC_POOL_REGISTRY: '0xddf1c516cf87126c6c610b52fd8d609e67fb6033'
+          NEXT_PUBLIC_POOLS_CONFIG: 'mainnetProduction'
+          NEXT_PUBLIC_POOLS_IPFS_HASH_OVERRIDE: 'QmZEh2BmAeRmwpE8NqcjDr42n3mxxJRfAvGGcGY2mESz2r'
+          NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
+          NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
+          NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://thegraph.centrifuge.io/subgraphs/name/centrifuge/tinlake-rewards'
+          NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
+
+      - name: Deploy To Netlify
+        uses: nwtgck/actions-netlify@v1.1
+        with:
+          alias: pr-${{ github.event.pull_request.number }}
+          deploy-message: ${{ github.event.commit.message }}
+          enable-pull-request-comment: true
+          functions-dir: ./tinlake-ui/functions
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          netlify-config-path: ./tinlake-ui/netlify.toml
+          publish-dir: ./tinlake-ui/out
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN  }}
+          NETLIFY_SITE_ID: ${{ secrets.TINLAKE_UI_MAINNET_DEV_NETLIFY_SITE_ID }}

--- a/.github/workflows/tinlake-ui-pull-request.yml
+++ b/.github/workflows/tinlake-ui-pull-request.yml
@@ -71,10 +71,9 @@ jobs:
           deploy-message: ${{ github.event.commit.message }}
           enable-pull-request-comment: true
           functions-dir: ./tinlake-ui/functions
-          github-deployment-environment: test-environment-kovan
-          github-deployment-description: test-description-kovan
           github-token: ${{ secrets.GITHUB_TOKEN }}
           netlify-config-path: ./tinlake-ui/netlify.toml
+          overwrites-pull-request-comment: false
           publish-dir: ./tinlake-ui/out
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN  }}
@@ -145,10 +144,9 @@ jobs:
           deploy-message: ${{ github.event.commit.message }}
           enable-pull-request-comment: true
           functions-dir: ./tinlake-ui/functions
-          github-deployment-environment: test-environment-mainnet
-          github-deployment-description: test-description-mainnet
           github-token: ${{ secrets.GITHUB_TOKEN }}
           netlify-config-path: ./tinlake-ui/netlify.toml
+          overwrites-pull-request-comment: false
           publish-dir: ./tinlake-ui/out
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN  }}

--- a/.github/workflows/tinlake-ui-pull-request.yml
+++ b/.github/workflows/tinlake-ui-pull-request.yml
@@ -65,7 +65,7 @@ jobs:
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify
-        uses: nwtgck/actions-netlify@v1.1
+        uses: nwtgck/actions-netlify@v1.2.0
         with:
           alias: pr-${{ github.event.pull_request.number }}
           deploy-message: ${{ github.event.commit.message }}
@@ -73,7 +73,6 @@ jobs:
           functions-dir: ./tinlake-ui/functions
           github-token: ${{ secrets.GITHUB_TOKEN }}
           netlify-config-path: ./tinlake-ui/netlify.toml
-          overwrites-pull-request-comment: false
           publish-dir: ./tinlake-ui/out
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN  }}
@@ -138,7 +137,7 @@ jobs:
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify
-        uses: nwtgck/actions-netlify@v1.1
+        uses: nwtgck/actions-netlify@v1.2.0
         with:
           alias: pr-${{ github.event.pull_request.number }}
           deploy-message: ${{ github.event.commit.message }}
@@ -146,7 +145,6 @@ jobs:
           functions-dir: ./tinlake-ui/functions
           github-token: ${{ secrets.GITHUB_TOKEN }}
           netlify-config-path: ./tinlake-ui/netlify.toml
-          overwrites-pull-request-comment: false
           publish-dir: ./tinlake-ui/out
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN  }}

--- a/.github/workflows/tinlake-ui-pull-request.yml
+++ b/.github/workflows/tinlake-ui-pull-request.yml
@@ -71,6 +71,8 @@ jobs:
           deploy-message: ${{ github.event.commit.message }}
           enable-pull-request-comment: true
           functions-dir: ./tinlake-ui/functions
+          github-deployment-environment: test-environment-kovan
+          github-deployment-description: test-description-kovan
           github-token: ${{ secrets.GITHUB_TOKEN }}
           netlify-config-path: ./tinlake-ui/netlify.toml
           publish-dir: ./tinlake-ui/out
@@ -143,6 +145,8 @@ jobs:
           deploy-message: ${{ github.event.commit.message }}
           enable-pull-request-comment: true
           functions-dir: ./tinlake-ui/functions
+          github-deployment-environment: test-environment-mainnet
+          github-deployment-description: test-description-mainnet
           github-token: ${{ secrets.GITHUB_TOKEN }}
           netlify-config-path: ./tinlake-ui/netlify.toml
           publish-dir: ./tinlake-ui/out

--- a/tinlake-ui/README.md
+++ b/tinlake-ui/README.md
@@ -70,13 +70,15 @@ There are a few flags you can use in your url query string to debug Tinlake:
 
 ### Environments
 
-| Name            | Description                                                                                              | Domain                                                                                        |
-| --------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| Pull Request    | <ul><li>Deploys from a pull request</li><li>Points to Kovan testnet</li><li>Unstable</li></ul>           | `pr-<pull-request-number>--dev-tinlake.netlify.app`                                           |
-| Dev             | <ul><li>Deploys from the `main` branch</li><li>Points to Kovan testnet</li><li>Unstable</li></ul>        | <a href="https://dev.tinlake.centrifuge.io">dev.tinlake.centrifuge.io</a>                     |
-| Kovan Staging   | <ul><li>Deploys from a release candidate branch</li><li>Points to Kovan testnet</li><li>Stable</li></ul> | <a href="https://kovan.staging.tinlake.centrifuge.io">kovan.staging.tinlake.centrifuge.io</a> |
-| Mainnet Staging | <ul><li>Deploys from a release candidate branch</li><li>Points to mainnet</li><li>Stable</li></ul>       | <a href="https://staging.tinlake.centrifuge.io">staging.tinlake.centrifuge.io</a>             |
-| Prod            | <ul><li>Deploys from a release tag</li><li>Points to mainnet</li><li>Production environment</li></ul>    | <a href="https://tinlake.centrifuge.io">tinlake.centrifuge.io</a>                             |
+| Name                 | Description                                                                                              | Domain                                                                                        |
+| -------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Kovan Pull Request   | <ul><li>Deploys from a pull request</li><li>Points to Kovan testnet</li><li>Unstable</li></ul>           | `pr-<pull-request-number>--kovan-dev-tinlake.netlify.app`                                     |
+| Mainnet Pull Request | <ul><li>Deploys from a pull request</li><li>Points to mainnet</li><li>Unstable</li></ul>                 | `pr-<pull-request-number>--dev-tinlake.netlify.app`                                           |
+| Kovan Dev            | <ul><li>Deploys from the `main` branch</li><li>Points to Kovan testnet</li><li>Unstable</li></ul>        | <a href="https://kovan.dev.tinlake.centrifuge.io">kovan.dev.tinlake.centrifuge.io</a>         |
+| Mainnet Dev          | <ul><li>Deploys from the `main` branch</li><li>Points to mainnet</li><li>Unstable</li></ul>              | <a href="https://dev.tinlake.centrifuge.io">dev.tinlake.centrifuge.io</a>                     |
+| Kovan Staging        | <ul><li>Deploys from a release candidate branch</li><li>Points to Kovan testnet</li><li>Stable</li></ul> | <a href="https://kovan.staging.tinlake.centrifuge.io">kovan.staging.tinlake.centrifuge.io</a> |
+| Mainnet Staging      | <ul><li>Deploys from a release candidate branch</li><li>Points to mainnet</li><li>Stable</li></ul>       | <a href="https://staging.tinlake.centrifuge.io">staging.tinlake.centrifuge.io</a>             |
+| Prod                 | <ul><li>Deploys from a release tag</li><li>Points to mainnet</li><li>Production environment</li></ul>    | <a href="https://tinlake.centrifuge.io">tinlake.centrifuge.io</a>                             |
 
 ### Release
 
@@ -84,17 +86,17 @@ There are a few flags you can use in your url query string to debug Tinlake:
 
 Here is a visual of the software development lifecycle for `tinlake-ui`:
 
-<img src="https://i.imgur.com/WY3BH8C.png" alt="proposed-process-diagram" width="575">
+<img src="https://i.imgur.com/7dDsHig.png" alt="proposed-process-diagram" width="575">
 
 Below is the flow for a typical release:
 
 ##### Deploy Pull Requests
 
-Deploys to `pr-<pull-request-number>--dev-tinlake.netlify.app` are automatically triggered when a pull request is submitted that contains changes to the `tinlake-ui` subdirectory
+Deploys to `pr-<pull-request-number>--kovan.dev-tinlake.netlify.app` and `pr-<pull-request-number>--dev-tinlake.netlify.app` are automatically triggered when a pull request is submitted that contains changes to the `tinlake-ui` subdirectory
 
 ##### Deploy To Development
 
-Deploys to <a href="https://dev.tinlake.centrifuge.io">dev.tinlake.centrifuge.io</a> are automatically triggered when changes are push/merged to the `main` branch that contains changes to the `tinlake-ui` subdirectory
+Deploys to <a href="https://kovan.dev.tinlake.centrifuge.io">kovan.dev.tinlake.centrifuge.io</a> and <a href="https://dev.tinlake.centrifuge.io">dev.tinlake.centrifuge.io</a> are automatically triggered when changes are push/merged to the `main` branch that contains changes to the `tinlake-ui` subdirectory
 
 ##### Deploy To Staging
 


### PR DESCRIPTION
### Description

This pull request refactors the Github Actions config to deploy pull requests to both `kovan` and `mainnet`. Also, deploys `main` branch to both `kovan` and `mainnet` as well. 