### PR TITLE
#371 hide rewards when wallet is not connected

### DIFF
--- a/tinlake-ui/components/Header/index.tsx
+++ b/tinlake-ui/components/Header/index.tsx
@@ -152,13 +152,15 @@ const Header: React.FC<Props> = (props: Props) => {
       <AccountWrapper align="center" direction="row">
         {!props.hideHoldings && (
           <Holdings>
-            <Box pad={{ left: '14px', right: '14px' }}>
-              <Tooltip title="View your rewards">{address ? rewardsLink : 'Rewards'}</Tooltip>
-            </Box>
             {address && (
-              <Box pad={{ left: '14px', right: '14px' }}>
-                <Tooltip title="View your investment portfolio">{portfolioLink}</Tooltip>
-              </Box>
+              <>
+                <Box pad={{ left: '14px', right: '14px' }}>
+                  <Tooltip title="View your rewards">{rewardsLink}</Tooltip>
+                </Box>
+                <Box pad={{ left: '14px', right: '14px' }}>
+                  <Tooltip title="View your investment portfolio">{portfolioLink}</Tooltip>
+                </Box>
+              </>
             )}
           </Holdings>
         )}
@@ -206,7 +208,7 @@ const Header: React.FC<Props> = (props: Props) => {
 
                 {!props.hideHoldings && (
                   <Box gap="large">
-                    {rewardsLink}
+                    {address && rewardsLink}
                     {address && portfolioLink}
                   </Box>
                 )}


### PR DESCRIPTION
Closes [#371](https://github.com/centrifuge/apps/issues/371)


## Not connected
![Screenshot 2021-09-14 at 09 26 34](https://user-images.githubusercontent.com/8630331/133214736-43cb36bf-d1e1-4050-aad2-13d5a77d0bd5.png)

![Screenshot 2021-09-14 at 09 27 00](https://user-images.githubusercontent.com/8630331/133214765-6f525b72-f82f-4ff3-a5e2-5122bae12dcb.png)


## Connected

![Screenshot 2021-09-14 at 09 28 09](https://user-images.githubusercontent.com/8630331/133214780-d2db8cd5-9f9e-4f5a-96b5-fb06d19d829c.png)

![Screenshot 2021-09-14 at 09 28 31](https://user-images.githubusercontent.com/8630331/133214792-b0ee537b-f311-4344-8c6f-51a2f85f4cb1.png)

![Screenshot 2021-09-14 at 09 28 46](https://user-images.githubusercontent.com/8630331/133214804-8b169bac-acf7-422e-bf64-e57c15083f54.png)
