### PR TITLE
Only render onboarding on client

### DIFF
--- a/tinlake-ui/components/ClientOnlyRender/index.tsx
+++ b/tinlake-ui/components/ClientOnlyRender/index.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react'
+
+export const ClientOnlyRender: React.FC = ({ children }) => {
+  const [shouldRender, setRender] = React.useState(false)
+
+  React.useEffect(() => {
+    setRender(true)
+  }, [])
+  return shouldRender ? <>{children}</> : null
+}

--- a/tinlake-ui/pages/pool/[root]/[slug]/onboarding/index.tsx
+++ b/tinlake-ui/pages/pool/[root]/[slug]/onboarding/index.tsx
@@ -4,6 +4,7 @@ import { WithRouterProps } from 'next/dist/client/with-router'
 import Head from 'next/head'
 import * as React from 'react'
 import Auth from '../../../../../components/Auth'
+import { ClientOnlyRender } from '../../../../../components/ClientOnlyRender'
 import Container from '../../../../../components/Container'
 import Header from '../../../../../components/Header'
 import { IpfsPoolsProvider } from '../../../../../components/IpfsPoolsProvider'
@@ -38,7 +39,9 @@ const OnboardingPage: React.FC<Props> = ({ pool, ipfsPools }) => {
               <Box width="xlarge">
                 <Auth>
                   <Box>
-                    <OnboardingSteps activePool={pool} />
+                    <ClientOnlyRender>
+                      <OnboardingSteps activePool={pool} />
+                    </ClientOnlyRender>
                   </Box>
                 </Auth>
               </Box>


### PR DESCRIPTION
NextJS is messing things up in a major way on the onboarding page, so only rendering it on the client now as a quick fix until we find a better one.

![image](https://user-images.githubusercontent.com/23527729/134170893-3b3bae59-6283-4446-9d99-22697b650ff2.png)
