### PR TITLE
Update pool status view

### DIFF
--- a/tinlake-ui/components/Overview/index.tsx
+++ b/tinlake-ui/components/Overview/index.tsx
@@ -34,7 +34,7 @@ const Overview: React.FC<Props> = ({ selectedPool }) => {
   }
 
   return (
-    <Stack gap="xlarge" mt="large">
+    <Stack gap="xlarge" mt="xlarge">
       {!isUpcomingPool(selectedPool) && (
         <div>
           <PageTitle

--- a/tinlake-ui/components/Overview/index.tsx
+++ b/tinlake-ui/components/Overview/index.tsx
@@ -99,7 +99,7 @@ const Overview: React.FC<Props> = ({ selectedPool }) => {
       </div>
 
       <div>
-        <Heading level="4">Pool Balance</Heading>
+        <Heading level="4">Pool Status</Heading>
         <InvestmentOverview selectedPool={selectedPool} />
       </div>
 

--- a/tinlake-ui/components/Overview/index.tsx
+++ b/tinlake-ui/components/Overview/index.tsx
@@ -97,29 +97,7 @@ const Overview: React.FC<Props> = ({ selectedPool }) => {
           </Stack>
         </Card>
       </div>
-      {/* </Box>{' '} */}
-      {/* <Box basis="1/3">
-          <Heading level="4">Tweets by @NewSilverLend</Heading>
-          <Box
-            elevation="small"
-            round="xsmall"
-            pad="small"
-            margin={{ bottom: 'large' }}
-            width="100%"
-            height="100%"
-            background="white"
-          >
-            <TwitterTimelineEmbed
-              sourceType="profile"
-              screenName="NewSilverLend"
-              autoHeight
-              noHeader
-              noFooter
-              noBorders
-            />
-          </Box>
-        </Box>
-      </Box> */}
+
       <div>
         <Heading level="4">Pool Balance</Heading>
         <InvestmentOverview selectedPool={selectedPool} />

--- a/tinlake-ui/containers/Investment/View/InvestmentOverview.tsx
+++ b/tinlake-ui/containers/Investment/View/InvestmentOverview.tsx
@@ -11,6 +11,7 @@ import { Tooltip } from '../../../components/Tooltip'
 import { ValuePairList } from '../../../components/ValuePairList'
 import { Pool, UpcomingPool } from '../../../config'
 import { addThousandsSeparators } from '../../../utils/addThousandsSeparators'
+import { useTrancheYield } from '../../../utils/hooks'
 import { toPrecision } from '../../../utils/toPrecision'
 import { useAssets } from '../../../utils/useAssets'
 import { usePool } from '../../../utils/usePool'
@@ -55,12 +56,7 @@ const InvestmentOverview: React.FC<Props> = (props: Props) => {
   const minJuniorRatio = poolData ? parseRatio(poolData.minJuniorRatio) : undefined
   const currentJuniorRatio = poolData ? parseRatio(poolData.currentJuniorRatio) : undefined
 
-  // const { dropYield } = useTrancheYield(tinlake.contractAddresses.ROOT_CONTRACT)
-  let dropYield = ''
-
-  setTimeout(() => {
-    dropYield = '666'
-  }, 2000)
+  const { dropYield } = useTrancheYield(tinlake.contractAddresses.ROOT_CONTRACT)
 
   const reserveRatio =
     poolData && !poolData.reserve.add(poolData.netAssetValue).isZero()
@@ -75,10 +71,6 @@ const InvestmentOverview: React.FC<Props> = (props: Props) => {
   const availableLiquidityVal = isMaker
     ? poolData?.reserve.add(poolData?.maker?.remainingCredit || new BN(0))
     : poolData?.reserve
-
-  React.useEffect(() => {
-    console.log('dropYield', dropYield)
-  }, [dropYield])
 
   return (
     <>

--- a/tinlake-ui/containers/Investment/View/InvestmentOverview.tsx
+++ b/tinlake-ui/containers/Investment/View/InvestmentOverview.tsx
@@ -7,7 +7,6 @@ import { SectionHeading } from '../../../components/Heading'
 import { Box, Shelf, Stack } from '../../../components/Layout'
 import { useTinlake } from '../../../components/TinlakeProvider'
 import { Tooltip } from '../../../components/Tooltip'
-import { Value } from '../../../components/Value'
 import { ValuePairList } from '../../../components/ValuePairList'
 import { Pool, UpcomingPool } from '../../../config'
 import { addThousandsSeparators } from '../../../utils/addThousandsSeparators'
@@ -15,7 +14,7 @@ import { useTrancheYield } from '../../../utils/hooks'
 import { toPrecision } from '../../../utils/toPrecision'
 import { useAssets } from '../../../utils/useAssets'
 import { usePool } from '../../../utils/usePool'
-import { DividerBottom, DividerInner, DividerTop, FlexWrapper, TokenLogo } from './styles'
+import { DividerInner, FlexWrapper, TokenLogo } from './styles'
 
 interface Props {
   selectedPool: Pool | UpcomingPool
@@ -151,19 +150,12 @@ const InvestmentOverview: React.FC<Props> = (props: Props) => {
           />
         </Card>
         <Stack flex="1 1 35%" justifyContent="space-between">
-          <Card p="medium" mb="small">
+          <Card p="medium">
             <Shelf justifyContent="space-between">
               <Shelf gap="xsmall" mb="xsmall">
                 <Box as={TokenLogo} src="/static/DROP_final.svg" display={['none', 'inline']} />
                 <SectionHeading>DROP Tranche</SectionHeading>
               </Shelf>
-              <Value
-                variant="sectionHeading"
-                value={
-                  dropTotalValue ? addThousandsSeparators(toPrecision(baseToDisplay(dropTotalValue, 27 + 18), 0)) : null
-                }
-                unit={props.selectedPool.metadata.currencySymbol || 'DAI'}
-              />
             </Shelf>
             <Stack gap="small">
               <TrancheNote>Senior tranche &mdash; Lower risk, stable return</TrancheNote>
@@ -176,7 +168,6 @@ const InvestmentOverview: React.FC<Props> = (props: Props) => {
                     value: poolData?.senior
                       ? addThousandsSeparators(toPrecision(baseToDisplay(poolData?.senior!.tokenPrice || '0', 27), 4))
                       : null,
-                    valueUnit: '%',
                   },
                   dropYield && !(poolData?.netAssetValue.isZero() && poolData?.reserve.isZero())
                     ? {
@@ -194,26 +185,21 @@ const InvestmentOverview: React.FC<Props> = (props: Props) => {
             </Stack>
           </Card>
 
-          <DividerTop>
-            <DividerInner>&nbsp;</DividerInner>
-          </DividerTop>
+          <DividerInner>&nbsp;</DividerInner>
 
-          <Box mt="xsmall" mb="medium" textAlign="center">
+          <Box mt="xsmall" mb="xsmall" textAlign="center">
             <div>
-              DROP is currently protected by a<br />
-              <span style={{ fontWeight: 'bold' }}>
-                {toPrecision((Math.round((currentJuniorRatio || 0) * 10000) / 100).toString(), 2)}%{' '}
-                <Tooltip id="tinRiskBuffer" underline>
-                  TIN buffer
-                </Tooltip>
-              </span>{' '}
+              DROP is currently protected by a{' '}
+              <Tooltip id="tinRiskBuffer" underline>
+                <span style={{ fontWeight: 'bold' }}>
+                  {toPrecision((Math.round((currentJuniorRatio || 0) * 10000) / 100).toString(), 2)}% TIN buffer
+                </span>
+              </Tooltip>{' '}
               (min: {toPrecision((Math.round((minJuniorRatio || 0) * 10000) / 100).toString(), 2)}%)
             </div>
           </Box>
 
-          <DividerBottom>
-            <DividerInner>&nbsp;</DividerInner>
-          </DividerBottom>
+          <DividerInner>&nbsp;</DividerInner>
 
           <Card p="medium">
             <Shelf justifyContent="space-between">
@@ -221,13 +207,6 @@ const InvestmentOverview: React.FC<Props> = (props: Props) => {
                 <Box as={TokenLogo} src="/static/TIN_final.svg" display={['none', 'inline']} />
                 <SectionHeading>Tin Tranche</SectionHeading>
               </Shelf>
-              <Value
-                variant="sectionHeading"
-                value={
-                  tinTotalValue ? addThousandsSeparators(toPrecision(baseToDisplay(tinTotalValue, 27 + 18), 0)) : null
-                }
-                unit={props.selectedPool.metadata.currencySymbol || 'DAI'}
-              />
             </Shelf>
             <Stack gap="small">
               <TrancheNote>Junior tranche &mdash; Higher risk, variable return</TrancheNote>

--- a/tinlake-ui/containers/Investment/View/InvestmentOverview.tsx
+++ b/tinlake-ui/containers/Investment/View/InvestmentOverview.tsx
@@ -186,7 +186,7 @@ const InvestmentOverview: React.FC<Props> = (props: Props) => {
 
           <Box mt="xsmall" mb="xsmall" textAlign="center">
             <div>
-              DROP is currently protected by a{' '}
+              DROP is protected by a{' '}
               <Tooltip id="tinRiskBuffer" underline>
                 <span style={{ fontWeight: 'bold' }}>
                   {toPrecision((Math.round((currentJuniorRatio || 0) * 10000) / 100).toString(), 2)}% TIN buffer

--- a/tinlake-ui/containers/Investment/View/InvestmentOverview.tsx
+++ b/tinlake-ui/containers/Investment/View/InvestmentOverview.tsx
@@ -5,12 +5,12 @@ import styled from 'styled-components'
 import { Card } from '../../../components/Card'
 import { SectionHeading } from '../../../components/Heading'
 import { Box, Shelf, Stack } from '../../../components/Layout'
+import { LoadingValue } from '../../../components/LoadingValue'
 import { useTinlake } from '../../../components/TinlakeProvider'
 import { Tooltip } from '../../../components/Tooltip'
 import { ValuePairList } from '../../../components/ValuePairList'
 import { Pool, UpcomingPool } from '../../../config'
 import { addThousandsSeparators } from '../../../utils/addThousandsSeparators'
-import { useTrancheYield } from '../../../utils/hooks'
 import { toPrecision } from '../../../utils/toPrecision'
 import { useAssets } from '../../../utils/useAssets'
 import { usePool } from '../../../utils/usePool'
@@ -55,7 +55,12 @@ const InvestmentOverview: React.FC<Props> = (props: Props) => {
   const minJuniorRatio = poolData ? parseRatio(poolData.minJuniorRatio) : undefined
   const currentJuniorRatio = poolData ? parseRatio(poolData.currentJuniorRatio) : undefined
 
-  const { dropYield } = useTrancheYield(tinlake.contractAddresses.ROOT_CONTRACT)
+  // const { dropYield } = useTrancheYield(tinlake.contractAddresses.ROOT_CONTRACT)
+  let dropYield = ''
+
+  setTimeout(() => {
+    dropYield = '666'
+  }, 2000)
 
   const reserveRatio =
     poolData && !poolData.reserve.add(poolData.netAssetValue).isZero()
@@ -70,6 +75,10 @@ const InvestmentOverview: React.FC<Props> = (props: Props) => {
   const availableLiquidityVal = isMaker
     ? poolData?.reserve.add(poolData?.maker?.remainingCredit || new BN(0))
     : poolData?.reserve
+
+  React.useEffect(() => {
+    console.log('dropYield', dropYield)
+  }, [dropYield])
 
   return (
     <>
@@ -174,7 +183,9 @@ const InvestmentOverview: React.FC<Props> = (props: Props) => {
                       }
                     : {
                         term: 'Fixed DROP rate (APR)',
-                        value: toPrecision(feeToInterestRate(poolData?.senior?.interestRate || '0'), 2),
+                        value:
+                          poolData?.senior?.interestRate &&
+                          toPrecision(feeToInterestRate(poolData?.senior?.interestRate || '0'), 2),
                         valueUnit: '%',
                       },
                 ]}
@@ -189,11 +200,16 @@ const InvestmentOverview: React.FC<Props> = (props: Props) => {
               DROP is protected by a{' '}
               <Tooltip id="tinRiskBuffer" underline>
                 <span style={{ fontWeight: 'bold' }}>
-                  {toPrecision((Math.round((currentJuniorRatio || 0) * 10000) / 100).toString(), 2)}% TIN buffer
+                  <LoadingValue done={!!currentJuniorRatio}>
+                    {toPrecision((Math.round((currentJuniorRatio || 0) * 10000) / 100).toString(), 2)}%
+                  </LoadingValue>{' '}
+                  TIN buffer
                 </span>
               </Tooltip>{' '}
               <Tooltip id="minimumTinRiskBuffer" underline>
-                (min: {toPrecision((Math.round((minJuniorRatio || 0) * 10000) / 100).toString(), 2)}%)
+                <LoadingValue done={!!minJuniorRatio}>
+                  (min: {toPrecision((Math.round((minJuniorRatio || 0) * 10000) / 100).toString(), 2)}%)
+                </LoadingValue>
               </Tooltip>
             </div>
           </Box>

--- a/tinlake-ui/containers/Investment/View/InvestmentOverview.tsx
+++ b/tinlake-ui/containers/Investment/View/InvestmentOverview.tsx
@@ -214,7 +214,7 @@ const InvestmentOverview: React.FC<Props> = (props: Props) => {
                 variant="tertiary"
                 items={[
                   {
-                    term: 'Current token price',
+                    term: 'Token price',
                     value: poolData?.senior
                       ? addThousandsSeparators(toPrecision(baseToDisplay(poolData?.junior.tokenPrice || '0', 27), 4))
                       : null,

--- a/tinlake-ui/containers/Investment/View/InvestmentOverview.tsx
+++ b/tinlake-ui/containers/Investment/View/InvestmentOverview.tsx
@@ -52,9 +52,6 @@ const InvestmentOverview: React.FC<Props> = (props: Props) => {
         }, 0) / ongoingAssets.length
     : undefined
 
-  const dropTotalValue = poolData?.senior ? poolData?.senior.totalSupply.mul(poolData.senior!.tokenPrice) : undefined
-  const tinTotalValue = poolData ? poolData.junior.totalSupply.mul(poolData?.junior.tokenPrice) : undefined
-
   const minJuniorRatio = poolData ? parseRatio(poolData.minJuniorRatio) : undefined
   const currentJuniorRatio = poolData ? parseRatio(poolData.currentJuniorRatio) : undefined
 

--- a/tinlake-ui/containers/Investment/View/InvestmentOverview.tsx
+++ b/tinlake-ui/containers/Investment/View/InvestmentOverview.tsx
@@ -15,18 +15,7 @@ import { useTrancheYield } from '../../../utils/hooks'
 import { toPrecision } from '../../../utils/toPrecision'
 import { useAssets } from '../../../utils/useAssets'
 import { usePool } from '../../../utils/usePool'
-import {
-  BalanceSheetDiagram,
-  BalanceSheetDiagramLeft,
-  BalanceSheetDiagramRight,
-  BalanceSheetFiller,
-  BalanceSheetMidLine,
-  DividerBottom,
-  DividerInner,
-  DividerTop,
-  FlexWrapper,
-  TokenLogo,
-} from './styles'
+import { DividerBottom, DividerInner, DividerTop, FlexWrapper, TokenLogo } from './styles'
 
 interface Props {
   selectedPool: Pool | UpcomingPool
@@ -90,7 +79,7 @@ const InvestmentOverview: React.FC<Props> = (props: Props) => {
   return (
     <>
       <FlexWrapper>
-        <Card p="medium" flex="1 1 35%">
+        <Card p="medium" flex="1 1 35%" mr={['0', '0', 'medium']}>
           <Shelf mb="small" justifyContent="space-between">
             <SectionHeading>
               <Tooltip id="assetValue" underline>
@@ -166,14 +155,6 @@ const InvestmentOverview: React.FC<Props> = (props: Props) => {
             ]}
           />
         </Card>
-        <BalanceSheetDiagram direction="row">
-          <BalanceSheetDiagramLeft>
-            <BalanceSheetMidLine>&nbsp;</BalanceSheetMidLine>
-            <BalanceSheetFiller>&nbsp;</BalanceSheetFiller>
-          </BalanceSheetDiagramLeft>
-          <BalanceSheetDiagramRight>&nbsp;</BalanceSheetDiagramRight>
-        </BalanceSheetDiagram>
-
         <Stack flex="1 1 35%" justifyContent="space-between">
           <Card p="medium" mb="small">
             <Shelf justifyContent="space-between">

--- a/tinlake-ui/containers/Investment/View/InvestmentOverview.tsx
+++ b/tinlake-ui/containers/Investment/View/InvestmentOverview.tsx
@@ -68,7 +68,7 @@ const InvestmentOverview: React.FC<Props> = (props: Props) => {
   const isMaker = !!poolData?.maker
 
   const availableLiquidityVal = isMaker
-    ? poolData?.reserve.add(poolData?.maker?.creditline || new BN(0))
+    ? poolData?.reserve.add(poolData?.maker?.remainingCredit || new BN(0))
     : poolData?.reserve
 
   return (
@@ -192,7 +192,9 @@ const InvestmentOverview: React.FC<Props> = (props: Props) => {
                   {toPrecision((Math.round((currentJuniorRatio || 0) * 10000) / 100).toString(), 2)}% TIN buffer
                 </span>
               </Tooltip>{' '}
-              (min: {toPrecision((Math.round((minJuniorRatio || 0) * 10000) / 100).toString(), 2)}%)
+              <Tooltip id="minimumTinRiskBuffer" underline>
+                (min: {toPrecision((Math.round((minJuniorRatio || 0) * 10000) / 100).toString(), 2)}%)
+              </Tooltip>
             </div>
           </Box>
 
@@ -202,7 +204,7 @@ const InvestmentOverview: React.FC<Props> = (props: Props) => {
             <Shelf justifyContent="space-between">
               <Shelf gap="xsmall" mb="xsmall">
                 <Box as={TokenLogo} src="/static/TIN_final.svg" display={['none', 'inline']} />
-                <SectionHeading>Tin Tranche</SectionHeading>
+                <SectionHeading>TIN Tranche</SectionHeading>
               </Shelf>
             </Shelf>
             <Stack gap="small">

--- a/tinlake-ui/containers/Investment/View/InvestmentOverview.tsx
+++ b/tinlake-ui/containers/Investment/View/InvestmentOverview.tsx
@@ -161,14 +161,14 @@ const InvestmentOverview: React.FC<Props> = (props: Props) => {
                 variant="tertiary"
                 items={[
                   {
-                    term: 'Current token price',
+                    term: 'Token price',
                     value: poolData?.senior
                       ? addThousandsSeparators(toPrecision(baseToDisplay(poolData?.senior!.tokenPrice || '0', 27), 4))
                       : null,
                   },
                   dropYield && !(poolData?.netAssetValue.isZero() && poolData?.reserve.isZero())
                     ? {
-                        term: 'Current DROP yield (30d APY)',
+                        term: 'DROP yield (30d APY)',
                         value: dropYield,
                         valueUnit: '%',
                       }

--- a/tinlake-ui/containers/Investment/View/styles.tsx
+++ b/tinlake-ui/containers/Investment/View/styles.tsx
@@ -95,20 +95,8 @@ export const PoolValueLineRight = styled.div`
   margin-top: 40px;
 `
 
-export const DividerTop = styled.div`
-  border-bottom: 1px solid #d8d8d8;
-  max-width: 80%;
-  margin: 0 0 16px 10%;
-`
-
-export const DividerBottom = styled.div`
-  border-top: 1px solid #d8d8d8;
-  max-width: 80%;
-  margin: 0 0 16px 10%;
-`
-
 export const DividerInner = styled.div`
-  border-right: 1px solid #d8d8d8;
+  border-right: 1px solid #e0e0e0;
   width: 50%;
 `
 

--- a/tinlake-ui/containers/Investment/View/styles.tsx
+++ b/tinlake-ui/containers/Investment/View/styles.tsx
@@ -95,40 +95,6 @@ export const PoolValueLineRight = styled.div`
   margin-top: 40px;
 `
 
-export const BalanceSheetDiagram = styled(Box)`
-  flex: 1 1 10%;
-  @media (max-width: 899px) {
-    display: none;
-  }
-`
-
-export const BalanceSheetDiagramLeft = styled(Box)`
-  width: 50%;
-  display: flex;
-  flex-direction: column;
-`
-
-export const BalanceSheetMidLine = styled.div`
-  border-bottom: 1px solid #d8d8d8;
-  flex: 1;
-`
-
-export const BalanceSheetFiller = styled.div`
-  flex: 1;
-`
-
-export const BalanceSheetDiagramRight = styled(Box)`
-  border-bottom: 1px solid #d8d8d8;
-  border-left: 1px solid #d8d8d8;
-  border-bottom-left-radius: 12px;
-  border-top-left-radius: 12px;
-  border-top: 1px solid #d8d8d8;
-  width: 50%;
-  height: 68%;
-  position: relative;
-  top: 14%;
-`
-
 export const DividerTop = styled.div`
   border-bottom: 1px solid #d8d8d8;
   max-width: 80%;

--- a/tinlake-ui/public/static/tooltips.json
+++ b/tinlake-ui/public/static/tooltips.json
@@ -31,7 +31,7 @@
   "tinRiskBuffer": {
     "title": "TIN Risk Buffer",
     "description": "The TIN risk buffer is the current value of the junior tranche (TIN) in relation to the pool value. It denotes how much of the pool is currently protected by the junior tranche.",
-    "link": "https://developer.centrifuge.io/tinlake/overview/tranches/"
+    "link": "https://docs.centrifuge.io/learn/drop-and-tin/"
   },
   "minimumTinRiskBuffer": {
     "title": "Minimum TIN risk buffer",
@@ -44,12 +44,12 @@
   "dropValue": {
     "title": "DROP Tranche Value",
     "description": "Total value of outstanding DROP tokens at the current DROP token price. DROP is Tinlake's senior token with a fixed interest rate (\"DROP APR\") and stable returns. DROP is protected against defaults of the underlying assets by TIN which takes losses first.",
-    "link": "https://developer.centrifuge.io/tinlake/overview/tranches/"
+    "link": "https://docs.centrifuge.io/learn/drop-and-tin/"
   },
   "tinValue": {
     "title": "TIN Tranche Value",
     "description": "Total value of outstanding TIN tokens at the current TIN token price. TIN is Tinlake's junior token. It protects DROP against defaults of the underlying assets by taking losses first. In return TIN has a higher, yet more volatile return than DROP.",
-    "link": "https://developer.centrifuge.io/tinlake/overview/tranches/"
+    "link": "https://docs.centrifuge.io/learn/drop-and-tin/"
   },
   "epochNumber": {
     "title": "Epoch #",

--- a/tinlake-ui/public/static/tooltips.json
+++ b/tinlake-ui/public/static/tooltips.json
@@ -108,5 +108,17 @@
   "dropInvestment": {
     "title": "DROP Investment",
     "description": "DROP tokens earn yield on the outstanding assets at the DROP APR. The effective APY may deviate due to compounding effects or unused liquidity in the pool reserve. The 30d DROP APY is the effective annualized return of the pool's DROP token over the last 30 days."
+  },
+  "availableLiquidity": {
+    "title": "Available liquidity",
+    "description": "Liquidity of the pool reserve available for redemptions by investors and originations by the Issuer."
+  },
+  "availableLiquidityMaker": {
+    "title": "Available liquidity",
+    "description": "Liquidity from the pool’s reserve or Maker vault available for redemptions by investors and originations by the Issuer."
+  },
+  "cashDrag": {
+    "title": "Cash drag",
+    "description": "Share of the pool’s investments that is currently in the pool’s reserve and not financing assets. Liquidity in the pool’s reserve does not earn yield and thus drags down investor’s returns."
   }
 }

--- a/tinlake-ui/public/static/tooltips.json
+++ b/tinlake-ui/public/static/tooltips.json
@@ -33,6 +33,10 @@
     "description": "The TIN risk buffer is the current value of the junior tranche (TIN) in relation to the pool value. It denotes how much of the pool is currently protected by the junior tranche.",
     "link": "https://developer.centrifuge.io/tinlake/overview/tranches/"
   },
+  "minimumTinRiskBuffer": {
+    "title": "Minimum TIN risk buffer",
+    "description": "The TIN risk buffer is the current value of the junior tranche (TIN) in relation to the pool value. The minimum TIN risk buffer indicates the lower limit and ensures that senior investors in DROP are protected by a certain amount of TIN invested in the pool at any time."
+  },
   "outstandingVolume": {
     "title": "Outstanding Volume",
     "description": "Sum of current outstanding financings by the asset originator. This deviates from the asset value, which considers expected repayments and risk-adjustments."

--- a/tinlake-ui/public/static/tooltips.json
+++ b/tinlake-ui/public/static/tooltips.json
@@ -30,7 +30,7 @@
   },
   "tinRiskBuffer": {
     "title": "TIN Risk Buffer",
-    "description": "Current amount of TIN in relation to the pool value. The minimum TIN risk buffer indicates the lower limit and ensures that DROP investors are protected by a certain amount of TIN invested in the pool at any time.",
+    "description": "The TIN risk buffer is the current value of the junior tranche (TIN) in relation to the pool value. It denotes how much of the pool is currently protected by the junior tranche.",
     "link": "https://developer.centrifuge.io/tinlake/overview/tranches/"
   },
   "outstandingVolume": {


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

<!-- Describe the goal of this pull request and if possible, insight on the implementation choices. -->

This pull request applies the following design changes to the Poostatus section of the Pool overview page:

- Remove connection between asset and investment side and display both as columns
- New Title of section: "Pool Status"
- Asset side:
  - Add Titles: Asset & Liquidity
  - Rows under Assets
    - Remove average financing amount
  - Rows under Liquidity
    - Remove Reserve
    - Add Available Liquidity calculated as Available Liquidity = Reserve + Available Credit Line for Maker pools and Available Liquidity = Reserve for non-Maker pools
    - Rename Reserve Ratio to Cash drag
- Token/Investment side
  - Remove tranche values
  - Remove the % from the token price in the Drop component

<!-- This will link the pull request to a Github issue. Remove if there is no corresponding Github issue. -->

Closes #428

### Approvals

<!-- Depending on the nature of the pull request, remove the roles that are not necessary for this review. Intricate technical changes may require two dev approvals. Reviewers should check the corresponding box after they approve. -->

- [ ] Dev
- [ ] Designer
- [ ] Product

### Screenshots

<!-- Supporting screenshots, gifs, or videos to give reviewers an idea of how the pull request will affect the presentation of the app. -->

#### Large viewport


<img width="1188" alt="Screenshot 2021-10-05 at 15 03 17" src="https://user-images.githubusercontent.com/8630331/136028308-e5d5935e-6585-44ec-8bf5-68c96a0df5c5.png">

#### Small viewport

<img width="425" alt="Screenshot 2021-10-05 at 15 03 59" src="https://user-images.githubusercontent.com/8630331/136028321-1ba0d0a6-bb1d-48a0-929b-9594b3f85730.png">


### Impact

Tinlake UI, Pool overview page