### PR TITLE
Add timeout to changelog generator

### DIFF
--- a/.github/workflows/changelog-generator.yml
+++ b/.github/workflows/changelog-generator.yml
@@ -25,6 +25,7 @@ jobs:
         run: gem install github_changelog_generator
 
       - name: Run changelog generator
+        timeout-minutes: 10 # when GH API rate is exceeded, the generator hangs. Abort changelog generation in this case
         run: github_changelog_generator -u centrifuge -p apps --since-tag tinlake-ui/release-30 -t ${{ secrets.GITHUB_TOKEN }}
 
       - name: check for changes


### PR DESCRIPTION

### Description

This pull request adds a timeout to the changelog generator, in case it hangs (most probably due to hitting github API max quota)

### Approvals

- [ ] Dev


### Screenshots

n/a

### Impact

No impact