### PR TITLE
Add layout components

### DIFF
--- a/fabric/package.json
+++ b/fabric/package.json
@@ -34,6 +34,7 @@
     "@typescript-eslint/eslint-plugin": "^4.32.0",
     "@typescript-eslint/parser": "^4.32.0",
     "babel-loader": "^8.2.2",
+    "csstype": "^3.0.9",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",

--- a/fabric/src/components/Box/index.ts
+++ b/fabric/src/components/Box/index.ts
@@ -1,0 +1,71 @@
+import shouldForwardProp from '@styled-system/should-forward-prop'
+import * as CSS from 'csstype'
+import styled from 'styled-components'
+import {
+  background,
+  BackgroundProps,
+  border,
+  BorderProps,
+  color,
+  ColorProps,
+  compose,
+  flexbox,
+  FlexboxProps,
+  get,
+  grid,
+  GridProps,
+  layout,
+  LayoutProps,
+  position,
+  PositionProps,
+  ResponsiveValue,
+  space,
+  SpaceProps,
+  system,
+  textAlign,
+  TextAlignProps,
+  TLengthStyledSystem,
+} from 'styled-system'
+import { PropsOf } from '../../utils/types'
+
+interface BleedProps {
+  bleedX?: ResponsiveValue<CSS.Property.MarginLeft<TLengthStyledSystem>>
+  bleedY?: ResponsiveValue<CSS.Property.MarginLeft<TLengthStyledSystem>>
+}
+
+const bleed = system({
+  bleedX: {
+    properties: ['marginLeft', 'marginRight'],
+    scale: 'space',
+    transform: (n: string | number, scale: any) => `-${toPx(get(scale, n, n))}`,
+  },
+  bleedY: {
+    properties: ['marginTop', 'marginBottom'],
+    scale: 'space',
+    transform: (n: string | number, scale: any) => `-${toPx(get(scale, n, n))}`,
+  },
+})
+
+interface SystemProps
+  extends SpaceProps,
+    LayoutProps,
+    BackgroundProps,
+    ColorProps,
+    FlexboxProps,
+    GridProps,
+    BorderProps,
+    TextAlignProps,
+    PositionProps,
+    BleedProps {}
+
+export interface StyledBoxProps extends SystemProps {}
+
+export const Box = styled('div').withConfig({
+  shouldForwardProp: (prop) => shouldForwardProp(prop),
+})<StyledBoxProps>(compose(space, layout, background, color, flexbox, grid, border, textAlign, position, bleed))
+
+export type BoxProps = PropsOf<typeof Box>
+
+function toPx(n: number | string) {
+  return typeof n === 'number' ? `${n}px` : n
+}

--- a/fabric/src/components/Container/Container.stories.tsx
+++ b/fabric/src/components/Container/Container.stories.tsx
@@ -1,0 +1,18 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import React from 'react'
+import { Container } from '.'
+import { Box } from '../Box'
+
+export default {
+  title: 'Components/Container',
+  component: Container,
+} as ComponentMeta<typeof Container>
+
+type ContainerStory = ComponentStory<typeof Container>
+const Template: ContainerStory = (args) => (
+  <Container {...args}>
+    <Box backgroundColor="centrifugeBlue" width="100%" height={75} />
+  </Container>
+)
+
+export const Default = Template.bind({})

--- a/fabric/src/components/Container/index.ts
+++ b/fabric/src/components/Container/index.ts
@@ -1,0 +1,11 @@
+import styled from 'styled-components'
+import { Box, BoxProps } from '../Box'
+
+export const Container = styled(Box)({})
+
+Container.defaultProps = {
+  maxWidth: 'container',
+  mx: 'auto',
+}
+
+export type ContainerProps = BoxProps

--- a/fabric/src/components/Flex/index.ts
+++ b/fabric/src/components/Flex/index.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components'
+import { Box, BoxProps } from '../Box'
+
+export const Flex = styled(Box)`
+  display: flex;
+`
+
+export type FlexProps = BoxProps

--- a/fabric/src/components/Grid/index.tsx
+++ b/fabric/src/components/Grid/index.tsx
@@ -1,0 +1,53 @@
+import * as CSS from 'csstype'
+import React from 'react'
+import { ResponsiveValue, TLengthStyledSystem } from 'styled-system'
+import { mapResponsive } from '../../utils/styled'
+import { Box, BoxProps } from '../Box'
+
+interface OwnProps {
+  gap?: ResponsiveValue<CSS.Property.GridColumnGap<TLengthStyledSystem>>
+  rowGap?: ResponsiveValue<CSS.Property.GridRowGap<TLengthStyledSystem>>
+  equalRows?: boolean
+  equalColumns?: boolean
+  columns?: ResponsiveValue<number>
+  minColumnWidth?: ResponsiveValue<TLengthStyledSystem>
+}
+
+export type GridProps = OwnProps & BoxProps
+
+export const Grid: React.FC<GridProps> = ({
+  gap,
+  rowGap = gap,
+  equalRows,
+  equalColumns = false,
+  minColumnWidth,
+  columns = 2,
+  ...rest
+}) => {
+  const templateColumns = minColumnWidth
+    ? widthToColumns(minColumnWidth, equalColumns)
+    : countToColumns(columns, equalColumns)
+
+  return (
+    <Box
+      display="grid"
+      gridColumnGap={gap}
+      gridRowGap={rowGap}
+      gridTemplateColumns={templateColumns}
+      gridAutoRows={equalRows ? '1fr' : undefined}
+      {...rest}
+    />
+  )
+}
+
+function toPx(n: number | string) {
+  return typeof n === 'number' ? `${n}px` : n
+}
+
+function widthToColumns(width: ResponsiveValue<TLengthStyledSystem>, equalColumns: boolean) {
+  return mapResponsive(width, (value) => `repeat(auto-fit, minmax(${toPx(value)}, ${equalColumns ? '1fr' : 'auto'}))`)
+}
+
+function countToColumns(count: ResponsiveValue<number>, equalColumns: boolean) {
+  return mapResponsive(count, (value) => `repeat(${value}, ${equalColumns ? '1fr' : 'auto'})`)
+}

--- a/fabric/src/components/LayoutGrid/LayoutGrid.stories.tsx
+++ b/fabric/src/components/LayoutGrid/LayoutGrid.stories.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { LayoutGrid, LayoutGridItem } from '.'
+import { Box } from '../Box'
+
+export default {
+  title: 'Components/LayoutGrid',
+}
+
+export const Default = () => {
+  return (
+    <LayoutGrid>
+      <LayoutGridItem span={[4, 8, 12]}>
+        <Box backgroundColor="centrifugeBlue" height={100} />
+      </LayoutGridItem>
+
+      <LayoutGridItem span={[4, 4, 6]}>
+        <Box backgroundColor="centrifugeBlue" height={100} />
+      </LayoutGridItem>
+
+      <LayoutGridItem span={[4, 4, 6]}>
+        <Box backgroundColor="centrifugeBlue" height={100} />
+      </LayoutGridItem>
+
+      <LayoutGridItem span={[4, 5, 8]}>
+        <Box backgroundColor="centrifugeBlue" height={100} />
+      </LayoutGridItem>
+
+      <LayoutGridItem span={[4, 3, 4]}>
+        <Box backgroundColor="centrifugeBlue" height={100} />
+      </LayoutGridItem>
+
+      <LayoutGridItem span={[4, 6, 8]} push={[0, 1, 2]}>
+        <Box backgroundColor="centrifugeBlue" height={100} />
+      </LayoutGridItem>
+
+      <LayoutGridItem span={4} push={[0, 1, 2]}>
+        <Box backgroundColor="centrifugeBlue" height={100} />
+      </LayoutGridItem>
+
+      <LayoutGridItem span={4}>
+        <Box backgroundColor="centrifugeBlue" height={100} />
+      </LayoutGridItem>
+
+      <LayoutGridItem span={[4, 8, 4]}>
+        <Box backgroundColor="centrifugeBlue" height={100} />
+      </LayoutGridItem>
+    </LayoutGrid>
+  )
+}

--- a/fabric/src/components/LayoutGrid/index.tsx
+++ b/fabric/src/components/LayoutGrid/index.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react'
+import { ResponsiveValue } from 'styled-system'
+import { mapResponsive } from '../../utils/styled'
+import { Box } from '../Box'
+import { Grid } from '../Grid'
+
+export const LayoutGrid: React.FC = ({ children }) => {
+  return (
+    <Grid columns={[4, 8, 12]} gap={['gutterMobile', 'gutterTablet', 'gutterDesktop']}>
+      {children}
+    </Grid>
+  )
+}
+
+type ItemProps = {
+  span?: ResponsiveValue<number>
+  push?: ResponsiveValue<number>
+}
+
+export const LayoutGridItem: React.FC<ItemProps> = ({ span, push, children }) => {
+  return (
+    <>
+      {push && (
+        <Box
+          gridColumn={mapResponsive(push, (value) => (value === 0 ? '' : `auto / span ${value}`))}
+          display={mapResponsive(push, (value) => (value === 0 ? 'none' : 'initial'))}
+        />
+      )}
+      <Box gridColumn={mapResponsive(span, (value) => `auto / span ${value}`)}>{children}</Box>
+    </>
+  )
+}

--- a/fabric/src/components/Shelf/Shelf.stories.tsx
+++ b/fabric/src/components/Shelf/Shelf.stories.tsx
@@ -1,0 +1,30 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import React from 'react'
+import { Shelf } from '.'
+import { Box } from '../Box'
+
+export default {
+  title: 'Components/Shelf',
+  component: Shelf,
+  argTypes: {
+    alignItems: {
+      options: ['stretch', 'center', 'flex-start', 'flex-end'],
+      control: { type: 'select' },
+    },
+  },
+} as ComponentMeta<typeof Shelf>
+
+type ShelfStory = ComponentStory<typeof Shelf>
+const Template: ShelfStory = (args) => (
+  <Shelf {...args}>
+    <Box backgroundColor="centrifugeBlue" width={200} minHeight={75} />
+    <Box backgroundColor="centrifugeBlue" width={200} minHeight={50} />
+    <Box backgroundColor="centrifugeBlue" width={200} minHeight={60} />
+  </Shelf>
+)
+
+export const Default = Template.bind({})
+Default.args = {
+  gap: 2,
+  alignItems: 'center',
+}

--- a/fabric/src/components/Shelf/index.ts
+++ b/fabric/src/components/Shelf/index.ts
@@ -1,0 +1,23 @@
+import css from '@styled-system/css'
+import * as CSS from 'csstype'
+import styled from 'styled-components'
+import { ResponsiveValue, TLengthStyledSystem } from 'styled-system'
+import { Flex, FlexProps } from '../Flex'
+
+type StyledShelfProps = {
+  gap?: ResponsiveValue<CSS.Property.ColumnGap<TLengthStyledSystem>>
+  rowGap?: ResponsiveValue<CSS.Property.RowGap<TLengthStyledSystem>>
+}
+
+export const Shelf = styled(Flex)<StyledShelfProps>((props) =>
+  css({
+    columnGap: props.gap,
+    rowGap: props.rowGap != null ? props.rowGap : props.gap,
+  })
+)
+
+Shelf.defaultProps = {
+  alignItems: 'center',
+}
+
+export type ShelfProps = FlexProps & StyledShelfProps

--- a/fabric/src/components/Stack/Stack.stories.tsx
+++ b/fabric/src/components/Stack/Stack.stories.tsx
@@ -1,0 +1,30 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import React from 'react'
+import { Stack } from '.'
+import { Box } from '../Box'
+
+export default {
+  title: 'Components/Stack',
+  component: Stack,
+  argTypes: {
+    alignItems: {
+      options: ['stretch', 'center', 'flex-start', 'flex-end'],
+      control: { type: 'select' },
+    },
+  },
+} as ComponentMeta<typeof Stack>
+
+type StackStory = ComponentStory<typeof Stack>
+const Template: StackStory = (args) => (
+  <Stack {...args}>
+    <Box backgroundColor="centrifugeBlue" minWidth={200} height={75} />
+    <Box backgroundColor="centrifugeBlue" minWidth={150} height={75} />
+    <Box backgroundColor="centrifugeBlue" minWidth={250} height={75} />
+  </Stack>
+)
+
+export const Default = Template.bind({})
+Default.args = {
+  gap: 2,
+  alignItems: 'stretch',
+}

--- a/fabric/src/components/Stack/index.ts
+++ b/fabric/src/components/Stack/index.ts
@@ -1,0 +1,21 @@
+import css from '@styled-system/css'
+import * as CSS from 'csstype'
+import styled from 'styled-components'
+import { ResponsiveValue, TLengthStyledSystem } from 'styled-system'
+import { Flex, FlexProps } from '../Flex'
+
+type StyledStackProps = {
+  gap?: ResponsiveValue<CSS.Property.RowGap<TLengthStyledSystem>>
+}
+
+export const Stack = styled(Flex)<StyledStackProps>((props) =>
+  css({
+    gap: props.gap,
+  })
+)
+
+Stack.defaultProps = {
+  flexDirection: 'column',
+}
+
+export type StackProps = FlexProps & StyledStackProps

--- a/fabric/src/components/Text/Text.stories.tsx
+++ b/fabric/src/components/Text/Text.stories.tsx
@@ -2,40 +2,45 @@ import { ComponentMeta } from '@storybook/react'
 import React from 'react'
 import { useTheme } from 'styled-components'
 import { Text } from '.'
+import { Stack } from '../Stack'
 
 export default {
   title: 'Components/Text',
   component: Text,
 } as ComponentMeta<typeof Text>
 
-export const TextVariants: React.FC = () => {
+export const Variants: React.FC = () => {
   const theme = useTheme()
   return (
-    <div>
+    <Stack gap={2}>
       {Object.keys(theme.typography).map((variant: any) => (
         <Text variant={variant}>{variant}</Text>
       ))}
-    </div>
+    </Stack>
   )
 }
 
-export const BodyText: React.FC = () => {
+export const Body: React.FC = () => {
   return (
-    <>
-      <Text variant="heading2">Body 1</Text>
-      <Text variant="body1" as="p">
-        Lorem ipsum dolor sit amet <Text variant="emphasized">consectetur adipisicing</Text> elit. Corporis, ex?
-        Nesciunt consequatur consectetur magnam delectus distinctio ipsa{' '}
-        <Text variant="emphasized">tempore maiores</Text> pariatur ipsum necessitatibus harum ea, labore quas impedit id
-        iure perferendis.
-      </Text>
-      <Text variant="heading2">Body 2</Text>
-      <Text variant="body2" as="p">
-        Lorem ipsum dolor sit amet <Text variant="emphasized">consectetur adipisicing</Text> elit. Corporis, ex?
-        Nesciunt consequatur consectetur magnam delectus distinctio ipsa{' '}
-        <Text variant="emphasized">tempore maiores</Text> pariatur ipsum necessitatibus harum ea, labore quas impedit id
-        iure perferendis.
-      </Text>
-    </>
+    <Stack gap={3}>
+      <Stack gap={1}>
+        <Text variant="heading2">Body 1</Text>
+        <Text variant="body1" as="p">
+          Lorem ipsum dolor sit amet <Text variant="emphasized">consectetur adipisicing</Text> elit. Corporis, ex?
+          Nesciunt consequatur consectetur magnam delectus distinctio ipsa{' '}
+          <Text variant="emphasized">tempore maiores</Text> pariatur ipsum necessitatibus harum ea, labore quas impedit
+          id iure perferendis.
+        </Text>
+      </Stack>
+      <Stack gap={1}>
+        <Text variant="heading2">Body 2</Text>
+        <Text variant="body2" as="p">
+          Lorem ipsum dolor sit amet <Text variant="emphasized">consectetur adipisicing</Text> elit. Corporis, ex?
+          Nesciunt consequatur consectetur magnam delectus distinctio ipsa{' '}
+          <Text variant="emphasized">tempore maiores</Text> pariatur ipsum necessitatibus harum ea, labore quas impedit
+          id iure perferendis.
+        </Text>
+      </Stack>
+    </Stack>
   )
 }

--- a/fabric/src/components/Wrap/index.ts
+++ b/fabric/src/components/Wrap/index.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components'
+import { Shelf, ShelfProps } from '../Shelf'
+
+export const Wrap = styled(Shelf)`
+  flex-wrap: wrap;
+`
+
+export type WrapProps = ShelfProps

--- a/fabric/src/theme/index.ts
+++ b/fabric/src/theme/index.ts
@@ -8,6 +8,9 @@ export const theme = {
   typography,
   space,
   colors,
+  sizes: {
+    container: 1152,
+  },
   fonts: {
     standard:
       "AvenirNextLTW01, 'Avenir Next', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'",

--- a/fabric/src/utils/styled.ts
+++ b/fabric/src/utils/styled.ts
@@ -1,0 +1,32 @@
+import { ResponsiveValue } from 'styled-system'
+
+function isObject(value: any): value is object {
+  return value != null && !Array.isArray(value) && typeof value === 'object'
+}
+
+export function mapResponsive<ResponsiveInput extends ResponsiveValue<any>, Output>(
+  prop: ResponsiveInput,
+  mapper: (v: any) => Output
+): ResponsiveValue<Output> {
+  if (Array.isArray(prop)) {
+    return prop.map((item) => {
+      if (item === null) {
+        return null
+      }
+      return mapper(item)
+    })
+  }
+
+  if (isObject(prop)) {
+    return Object.entries(prop).reduce((result, [key, value]) => {
+      result[key] = mapper(value)
+      return result
+    }, {} as any)
+  }
+
+  if (prop != null) {
+    return mapper(prop)
+  }
+
+  return null
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2712,6 +2712,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^4.32.0
     "@typescript-eslint/parser": ^4.32.0
     babel-loader: ^8.2.2
+    csstype: ^3.0.9
     eslint: ^7.32.0
     eslint-config-prettier: ^8.3.0
     eslint-plugin-prettier: ^4.0.0
@@ -15971,7 +15972,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.0.2, csstype@npm:^3.0.8":
+"csstype@npm:^3.0.2, csstype@npm:^3.0.8, csstype@npm:^3.0.9":
   version: 3.0.9
   resolution: "csstype@npm:3.0.9"
   checksum: e5d6ebc4581d09537e620b78b6741b4b1ececc0eb3fec065be1d59d42685954276847969b9c3652e835553a33dd8a7995bbd5cc834c4142375de8b417a433880


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

Adds several layout components to Fabric

* Stack: for vertical spacing
<img width="308" alt="image" src="https://user-images.githubusercontent.com/23527729/136810251-b26c08bd-88cb-461e-bccc-d602b38277e4.png">

* Shelf: for horizontal spacing
<img width="668" alt="image" src="https://user-images.githubusercontent.com/23527729/136810210-af2492eb-11c5-4d06-99f4-04bfdf8a0fed.png">

* Wrap: for horizontal spacing with line wrapping

* LayoutGrid: a grid with 4, 8, and 12 columns on mobile, tablet and desktop respectively
<img width="1108" alt="image" src="https://user-images.githubusercontent.com/23527729/136810169-ddc1bfa2-3d06-452d-9441-90a7ce22b824.png">

* A few primitives: Box, Flex, Grid, to build to above components

### Approvals

<!-- Depending on the nature of the pull request, remove the roles that are not necessary for this review. Intricate technical changes may require two dev approvals. Reviewers should check the corresponding box after they approve. -->

- [ ] Dev

