### PR TITLE
Tinlake: Show pool values only pre-onboarding

### DIFF
--- a/tinlake-ui/containers/Investment/View/TrancheOverview.tsx
+++ b/tinlake-ui/containers/Investment/View/TrancheOverview.tsx
@@ -164,36 +164,6 @@ const TrancheOverview: React.FC<Props> = (props: Props) => {
       </TextButton>
     )
 
-  const secondaryValues = (
-    <Box mt="small">
-      <Tooltip title="DROP tokens earn yield on the outstanding assets at the fixed senior rate (APR). The current yield may deviate due to compounding effects or unused liquidity in the pool reserve. The current 30d senior APY is the annualized return of the pool's DROP token over the last 30 days.">
-        <ValuePairList
-          variant="tertiary"
-          items={
-            [
-              dropYield &&
-                !(poolData?.netAssetValue.isZero() && poolData?.reserve.isZero()) && {
-                  term: 'Current senior yield (30d APY)',
-                  value: dropYield,
-                  valueUnit: '%',
-                },
-              {
-                term: 'Fixed senior rate (APR)',
-                value: toPrecision(feeToInterestRate(trancheData?.interestRate || new BN(0)), 2),
-                valueUnit: '%',
-              },
-              {
-                term: 'Minimum investment amount',
-                value: 5000,
-                valueUnit: props.pool?.metadata.currencySymbol || 'DAI',
-              },
-            ].filter(Boolean) as any
-          }
-        />
-      </Tooltip>
-    </Box>
-  )
-
   React.useEffect(() => {
     if (props.pool?.metadata && !props.pool.metadata.issuerEmail) {
       console.warn('The "issuerEmail" field is blank for pool ', props.pool.metadata.name)
@@ -367,7 +337,6 @@ const TrancheOverview: React.FC<Props> = (props: Props) => {
         <>
           {card === 'home' && (
             <>
-              {secondaryValues}
               {epochData?.isBlockedState && (
                 <>
                   <Warning>
@@ -503,7 +472,33 @@ const TrancheOverview: React.FC<Props> = (props: Props) => {
           </>
         ) : (
           <>
-            {secondaryValues}
+            <Box mt="small">
+              <Tooltip title="DROP tokens earn yield on the outstanding assets at the fixed senior rate (APR). The current yield may deviate due to compounding effects or unused liquidity in the pool reserve. The current 30d senior APY is the annualized return of the pool's DROP token over the last 30 days.">
+                <ValuePairList
+                  variant="tertiary"
+                  items={
+                    [
+                      dropYield &&
+                        !(poolData?.netAssetValue.isZero() && poolData?.reserve.isZero()) && {
+                          term: 'Current senior yield (30d APY)',
+                          value: dropYield,
+                          valueUnit: '%',
+                        },
+                      {
+                        term: 'Fixed senior rate (APR)',
+                        value: toPrecision(feeToInterestRate(trancheData?.interestRate || new BN(0)), 2),
+                        valueUnit: '%',
+                      },
+                      {
+                        term: 'Minimum investment amount',
+                        value: 5000,
+                        valueUnit: props.pool?.metadata.currencySymbol || 'DAI',
+                      },
+                    ].filter(Boolean) as any
+                  }
+                />
+              </Tooltip>
+            </Box>
             <ButtonGroup mt="medium">
               <InvestAction pool={props.pool} tranche="senior" />
             </ButtonGroup>


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

<!-- Describe the goal of this pull request and if possible, insight on the implementation choices. -->

Show secondary pool values (APY, APR) only when not onboarded yet and not in junior tranche card.

<!-- This will link the pull request to a Github issue. Remove if there is no corresponding Github issue. -->


### Approvals

- [ ] Dev

### Screenshots

![image](https://user-images.githubusercontent.com/23527729/138675744-29264294-1e67-4625-9165-4b3cecf26290.png)

### Impact
Tinlake tranche cards
<!-- Describe what parts of the app were affected so that reviewers can direct their focus. -->
