### PR TITLE
Fabric: change when publish happens

### DIFF
--- a/.github/workflows/fabric-publish.yml
+++ b/.github/workflows/fabric-publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Dependencies
         run: yarn install
 
-      - name: Public
+      - name: Publish
         run: yarn publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/fabric-publish.yml
+++ b/.github/workflows/fabric-publish.yml
@@ -1,10 +1,8 @@
 name: 'Fabric publish'
 on:
   push:
-    branches:
-      - main
-    paths:
-      - 'fabric/**'
+    tags:
+      - fabric/v*
 
 jobs:
   build-and-deploy:
@@ -26,17 +24,6 @@ jobs:
 
       - name: Install Dependencies
         run: yarn install
-
-      - name: Fetch from main
-        run: git fetch origin main
-
-      - name: Bump version
-        run: |
-          git config --local user.name "fabric-publish"
-          yarn bump
-
-      - name: Push bumped version and changelog
-        run: git push --follow-tags origin main
 
       - name: Public
         run: yarn publish

--- a/fabric/README.md
+++ b/fabric/README.md
@@ -96,4 +96,4 @@ yarn approve
 
 ### Publishing a new version
 
-Merging to `main` will publish a new version. For generating the changelog, make sure to use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec in your commits, with `fabric` as the scope, e.g.: `feat(fabric): Add button component`
+Create a new branch and run `yarn bump`, which bumps the package version, updates the changelog, creates a commit and tags it. Push the branch/tag, which should publish the version to NPM. Open a PR to merge the changes to `main`. For generating the changelog, make sure to use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) spec in your commits, with `fabric` as the scope, e.g.: `feat(fabric): Add button component`


### PR DESCRIPTION

### Description

Change the Github Action for publishing Fabric to happen when a tag is pushed

### Approvals

<!-- Depending on the nature of the pull request, remove the roles that are not necessary for this review. Intricate technical changes may require two dev approvals. Reviewers should check the corresponding box after they approve. -->

- [ ] Dev