### PR TITLE
Fabric: publish first version and fix Github Action

### DIFF
--- a/.github/workflows/fabric-publish.yml
+++ b/.github/workflows/fabric-publish.yml
@@ -26,6 +26,6 @@ jobs:
         run: yarn install
 
       - name: Publish
-        run: yarn publish
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/fabric/CHANGELOG.md
+++ b/fabric/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.0.3](https://github.com/centrifuge/apps/compare/fabric/v0.0.2...fabric/v0.0.3) (2022-01-03)
+
 ### 0.0.2 (2022-01-03)
 
 

--- a/fabric/CHANGELOG.md
+++ b/fabric/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### 0.0.2 (2022-01-03)
+
+
+### Features
+
+* **fabric:** Add Github Action to publish Fabric ([#567](https://github.com/centrifuge/apps/issues/567)) ([2094230](https://github.com/centrifuge/apps/commit/209423015ddece52cb8067803e57f9edd7124b00))

--- a/fabric/package.json
+++ b/fabric/package.json
@@ -4,6 +4,7 @@
   "description": "Fabric Component Library",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "files": ["dist"],
   "scripts": {
     "build": "yarn build:icons && tsc",
     "prepare": "yarn build",

--- a/fabric/package.json
+++ b/fabric/package.json
@@ -1,10 +1,12 @@
 {
   "name": "@centrifuge/fabric",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Fabric Component Library",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "yarn build:icons && tsc",
     "prepare": "yarn build",

--- a/fabric/package.json
+++ b/fabric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/fabric",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Fabric Component Library",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Publishes the first version of Fabric. `yarn publish` didn't work, so replacing it with `npm publish`