### PR TITLE
Swap in split rewards subgraph

### DIFF
--- a/.github/workflows/tinlake-ui-deploy-to-dev.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-dev.yml
@@ -137,7 +137,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://thegraph.centrifuge.io/subgraphs/name/centrifuge/tinlake-rewards'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://thegraph.centrifuge.io/subgraphs/name/centrifuge/split-rewards'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/tinlake-ui-deploy-to-dev.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-dev.yml
@@ -137,7 +137,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://thegraph.centrifuge.io/subgraphs/name/centrifuge/split-rewards'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://thegraph.centrifuge.io/subgraphs/name/centrifuge/investor-tx-and-split-rewards'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/tinlake-ui-deploy-to-prod.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-prod.yml
@@ -61,7 +61,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://thegraph.centrifuge.io/subgraphs/name/centrifuge/tinlake-rewards'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://thegraph.centrifuge.io/subgraphs/name/centrifuge/split-rewards'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/tinlake-ui-deploy-to-prod.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-prod.yml
@@ -61,7 +61,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://thegraph.centrifuge.io/subgraphs/name/centrifuge/split-rewards'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://thegraph.centrifuge.io/subgraphs/name/centrifuge/investor-tx-and-split-rewards'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/tinlake-ui-deploy-to-staging.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-staging.yml
@@ -134,7 +134,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://thegraph.centrifuge.io/subgraphs/name/centrifuge/split-rewards'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://thegraph.centrifuge.io/subgraphs/name/centrifuge/investor-tx-and-split-rewards'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/tinlake-ui-deploy-to-staging.yml
+++ b/.github/workflows/tinlake-ui-deploy-to-staging.yml
@@ -134,7 +134,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://thegraph.centrifuge.io/subgraphs/name/centrifuge/tinlake-rewards'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://thegraph.centrifuge.io/subgraphs/name/centrifuge/split-rewards'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/tinlake-ui-pull-request.yml
+++ b/.github/workflows/tinlake-ui-pull-request.yml
@@ -135,7 +135,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://thegraph.centrifuge.io/subgraphs/name/centrifuge/tinlake-rewards'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://thegraph.centrifuge.io/subgraphs/name/centrifuge/split-rewards'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/.github/workflows/tinlake-ui-pull-request.yml
+++ b/.github/workflows/tinlake-ui-pull-request.yml
@@ -135,7 +135,7 @@ jobs:
           NEXT_PUBLIC_PORTIS_KEY: 'bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f'
           NEXT_PUBLIC_REWARDS_TREE_URL: 'https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json'
           NEXT_PUBLIC_RPC_URL: 'https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516'
-          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://thegraph.centrifuge.io/subgraphs/name/centrifuge/split-rewards'
+          NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL: 'https://thegraph.centrifuge.io/subgraphs/name/centrifuge/investor-tx-and-split-rewards'
           NEXT_PUBLIC_TRANSACTION_TIMEOUT: '3600'
 
       - name: Deploy To Netlify

--- a/tinlake-ui/.env.mainnet-example
+++ b/tinlake-ui/.env.mainnet-example
@@ -14,5 +14,5 @@ NEXT_PUBLIC_POOLS_IPFS_HASH_OVERRIDE=QmWQKDgdAqttGunWd3fpfDVWB4otswf4y8XE16tHaP4
 NEXT_PUBLIC_PORTIS_KEY=bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f
 NEXT_PUBLIC_REWARDS_TREE_URL=https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json
 NEXT_PUBLIC_RPC_URL=https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516
-NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL=https://thegraph.centrifuge.io/subgraphs/name/centrifuge/split-rewards
+NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL=https://thegraph.centrifuge.io/subgraphs/name/centrifuge/investor-tx-and-split-rewards
 NEXT_PUBLIC_TRANSACTION_TIMEOUT=3600

--- a/tinlake-ui/.env.mainnet-example
+++ b/tinlake-ui/.env.mainnet-example
@@ -14,5 +14,5 @@ NEXT_PUBLIC_POOLS_IPFS_HASH_OVERRIDE=QmWQKDgdAqttGunWd3fpfDVWB4otswf4y8XE16tHaP4
 NEXT_PUBLIC_PORTIS_KEY=bc9e2922-2ebd-4e2b-86f6-7c7855bdf07f
 NEXT_PUBLIC_REWARDS_TREE_URL=https://storage.googleapis.com/rad-rewards-trees-mainnet-production/latest.json
 NEXT_PUBLIC_RPC_URL=https://mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516
-NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL=https://thegraph.centrifuge.io/subgraphs/name/centrifuge/tinlake-rewards
+NEXT_PUBLIC_TINLAKE_DATA_BACKEND_URL=https://thegraph.centrifuge.io/subgraphs/name/centrifuge/split-rewards
 NEXT_PUBLIC_TRANSACTION_TIMEOUT=3600

--- a/tinlake-ui/containers/ClaimRewards/index.tsx
+++ b/tinlake-ui/containers/ClaimRewards/index.tsx
@@ -16,9 +16,11 @@ import { RewardStripe, Small } from './styles'
 interface Props {
   activeLink: UserRewardsLink
   portfolioValue: BN | undefined
+  portfolioTinValue: BN | undefined
+  portfolioDropValue: BN | undefined
 }
 
-const ClaimRewards: React.FC<Props> = ({ activeLink, portfolioValue }) => {
+const ClaimRewards: React.FC<Props> = ({ activeLink, portfolioValue, portfolioDropValue, portfolioTinValue }) => {
   const { data, refetchCentChain } = useUserRewards()
   const { data: claims } = useRewardClaims()
   const rewards = useGlobalRewards()
@@ -121,11 +123,18 @@ const ClaimRewards: React.FC<Props> = ({ activeLink, portfolioValue }) => {
               </>
             )}
             Stay invested to continue earning{' '}
-            {rewards.data?.rewardRate &&
+            {rewards.data?.dropRewardRate &&
+              rewards.data?.tinRewardRate &&
               portfolioValue &&
               addThousandsSeparators(
                 toDynamicPrecision(
-                  baseToDisplay(rewards.data?.rewardRate.mul(portfolioValue.toString()).toFixed(0), 18)
+                  baseToDisplay(
+                    rewards.data?.dropRewardRate
+                      ?.mul(portfolioDropValue?.toString() || 0)
+                      .add(rewards.data?.tinRewardRate?.mul(portfolioTinValue?.toString() || 0))
+                      .toFixed(0) || '0',
+                    18
+                  )
                 )
               )}{' '}
             CFG daily.

--- a/tinlake-ui/containers/UserRewards/index.tsx
+++ b/tinlake-ui/containers/UserRewards/index.tsx
@@ -198,6 +198,8 @@ const UserRewards: React.FC = () => {
                 <ClaimRewards
                   activeLink={userRewards.links[userRewards.links.length - 1]}
                   portfolioValue={portfolioValue}
+                  portfolioDropValue={portfolioDropValue}
+                  portfolioTinValue={portfolioTinValue}
                 />
               )}
             </Card>

--- a/tinlake-ui/containers/UserRewards/index.tsx
+++ b/tinlake-ui/containers/UserRewards/index.tsx
@@ -40,11 +40,6 @@ const UserRewards: React.FC = () => {
     ?.filter((tb) => tb.tranche === Tranche.senior)
     .reduce((sum, tb) => tb.value.add(sum), new BN(0))
 
-  // console.log(portfolio.data?.tokenBalances?.filter((tb) => tb.tranche === Tranche.senior))
-  // console.log(portfolioValue?.toString())
-  // console.log(portfolioDropValue?.toString())
-  // console.log(portfolioTinValue?.toString())
-
   const dispatch = useDispatch()
   const router = useRouter()
 

--- a/tinlake-ui/containers/UserRewards/index.tsx
+++ b/tinlake-ui/containers/UserRewards/index.tsx
@@ -20,7 +20,7 @@ import { shortAddr } from '../../utils/shortAddr'
 import { dynamicPrecision, toDynamicPrecision } from '../../utils/toDynamicPrecision'
 import { toPrecision } from '../../utils/toPrecision'
 import { useGlobalRewards } from '../../utils/useGlobalRewards'
-import { usePortfolio } from '../../utils/usePortfolio'
+import { Tranche, usePortfolio } from '../../utils/usePortfolio'
 import { UserRewardsData, UserRewardsLink, useUserRewards } from '../../utils/useUserRewards'
 import CentChainWalletDialog from '../CentChainWalletDialog'
 import ClaimRewards from '../ClaimRewards'
@@ -33,6 +33,18 @@ const UserRewards: React.FC = () => {
   const { address: ethAddr } = useAuth()
   const portfolio = usePortfolio()
   const portfolioValue = portfolio.data?.totalValue
+  const portfolioTinValue = portfolio.data?.tokenBalances
+    ?.filter((tb) => tb.tranche === Tranche.junior)
+    .reduce((sum, tb) => tb.value.add(sum), new BN(0))
+  const portfolioDropValue = portfolio.data?.tokenBalances
+    ?.filter((tb) => tb.tranche === Tranche.senior)
+    .reduce((sum, tb) => tb.value.add(sum), new BN(0))
+
+  // console.log(portfolio.data?.tokenBalances?.filter((tb) => tb.tranche === Tranche.senior))
+  // console.log(portfolioValue?.toString())
+  // console.log(portfolioDropValue?.toString())
+  // console.log(portfolioTinValue?.toString())
+
   const dispatch = useDispatch()
   const router = useRouter()
 
@@ -206,14 +218,14 @@ const UserRewards: React.FC = () => {
               token="CFG"
               borderBottom
             />
-            <MetricRow
+            {/* <MetricRow
               loading={!rewards.data}
               value={rewards.data?.rewardRate.mul(10000).toFixed(4) || ''}
               label="Daily Reward Rate"
               token="CFG"
               suffix={<span style={{ fontSize: 10, color: '#777777' }}> / 10k DAI</span>}
               borderBottom
-            />
+            /> */}
             <MetricRow
               loading={!rewards.data}
               value={baseToDisplay(rewards.data?.toDateRewardAggregateValue || new BN(0), 18)}

--- a/tinlake-ui/containers/UserRewards/index.tsx
+++ b/tinlake-ui/containers/UserRewards/index.tsx
@@ -79,7 +79,10 @@ const UserRewards: React.FC = () => {
               <Metric
                 loading={!rewards.data || !userRewards || !portfolioValue}
                 value={baseToDisplay(
-                  rewards.data?.rewardRate?.mul(portfolioValue?.toString() || 0).toFixed(0) || '0',
+                  rewards.data?.dropRewardRate
+                    ?.mul(portfolioDropValue?.toString() || 0)
+                    .add(rewards.data?.tinRewardRate?.mul(portfolioTinValue?.toString() || 0))
+                    .toFixed(0) || '0',
                   18
                 )}
                 label="Your Daily Rewards"
@@ -218,14 +221,22 @@ const UserRewards: React.FC = () => {
               token="CFG"
               borderBottom
             />
-            {/* <MetricRow
+            <MetricRow
               loading={!rewards.data}
-              value={rewards.data?.rewardRate.mul(10000).toFixed(4) || ''}
-              label="Daily Reward Rate"
+              value={rewards.data?.dropRewardRate.mul(10000).toFixed(4) || ''}
+              label="Daily Drop Reward Rate"
               token="CFG"
               suffix={<span style={{ fontSize: 10, color: '#777777' }}> / 10k DAI</span>}
               borderBottom
-            /> */}
+            />
+            <MetricRow
+              loading={!rewards.data}
+              value={rewards.data?.tinRewardRate.mul(10000).toFixed(4) || ''}
+              label="Daily Tin Reward Rate"
+              token="CFG"
+              suffix={<span style={{ fontSize: 10, color: '#777777' }}> / 10k DAI</span>}
+              borderBottom
+            />
             <MetricRow
               loading={!rewards.data}
               value={baseToDisplay(rewards.data?.toDateRewardAggregateValue || new BN(0), 18)}

--- a/tinlake-ui/containers/UserRewards/index.tsx
+++ b/tinlake-ui/containers/UserRewards/index.tsx
@@ -224,7 +224,7 @@ const UserRewards: React.FC = () => {
             <MetricRow
               loading={!rewards.data}
               value={rewards.data?.dropRewardRate.mul(10000).toFixed(4) || ''}
-              label="Daily Drop Reward Rate"
+              label="Daily DROP Reward Rate"
               token="CFG"
               suffix={<span style={{ fontSize: 10, color: '#777777' }}> / 10k DAI</span>}
               borderBottom
@@ -232,7 +232,7 @@ const UserRewards: React.FC = () => {
             <MetricRow
               loading={!rewards.data}
               value={rewards.data?.tinRewardRate.mul(10000).toFixed(4) || ''}
-              label="Daily Tin Reward Rate"
+              label="Daily TIN Reward Rate"
               token="CFG"
               suffix={<span style={{ fontSize: 10, color: '#777777' }}> / 10k DAI</span>}
               borderBottom

--- a/tinlake-ui/services/apollo/index.ts
+++ b/tinlake-ui/services/apollo/index.ts
@@ -16,7 +16,8 @@ import { UserRewardsData } from '../../utils/useUserRewards'
 export interface RewardsData {
   toDateRewardAggregateValue: BN
   toDateAORewardAggregateValue: BN
-  rewardRate: Decimal
+  dropRewardRate: Decimal
+  tinRewardRate: Decimal
   todayReward: BN
 }
 
@@ -337,7 +338,8 @@ class Apollo {
         query: gql`
           {
             rewardDayTotals(first: 1, skip: 1, orderBy: id, orderDirection: desc) {
-              rewardRate
+              dropRewardRate
+              tinRewardRate
               toDateRewardAggregateValue
               toDateAORewardAggregateValue
               todayReward
@@ -357,7 +359,8 @@ class Apollo {
     return {
       toDateRewardAggregateValue: new BN(new Decimal(data.toDateRewardAggregateValue).toFixed(0)),
       toDateAORewardAggregateValue: new BN(new Decimal(data.toDateAORewardAggregateValue).toFixed(0)),
-      rewardRate: new Decimal(data.rewardRate),
+      dropRewardRate: new Decimal(data.dropRewardRate),
+      tinRewardRate: new Decimal(data.tinRewardRate),
       todayReward: new BN(new Decimal(data.todayReward).toFixed(0)),
     }
   }

--- a/tinlake-ui/utils/hooks.ts
+++ b/tinlake-ui/utils/hooks.ts
@@ -53,15 +53,15 @@ export const useCFGYield = () => {
   const { data: wCFGPrice } = useQuery('wCFGPrice', () => getWCFGPrice(tinlake))
 
   return React.useMemo(() => {
-    if (wCFGPrice && rewards.data?.rewardRate) {
+    if (wCFGPrice && rewards.data?.dropRewardRate) {
       const DAYS = 365
-      const rewardRate = rewards.data.rewardRate.toNumber()
+      const rewardRate = rewards.data.dropRewardRate.toNumber()
 
       return (DAYS * rewardRate * wCFGPrice * 100).toString()
     }
 
     return null
-  }, [wCFGPrice, rewards.data?.rewardRate])
+  }, [wCFGPrice, rewards.data?.dropRewardRate])
 }
 
 async function getWCFGPrice(tinlake: ITinlake) {

--- a/tinlake-ui/utils/usePortfolio.ts
+++ b/tinlake-ui/utils/usePortfolio.ts
@@ -98,7 +98,6 @@ async function getPortfolio(ipfsPools: IpfsPools, address: string) {
   const updatesPerToken = await multicall<{ [key: string]: TokenResult }>(calls)
 
   const tokenBalances = Object.entries(updatesPerToken).map(([tokenId, tokenResult]) => {
-    console.log(tokenId)
     let tranche = Tranche.senior
     ipfsPools.active.flatMap((pool) => {
       if (tokenId === pool.addresses.JUNIOR_TOKEN) {

--- a/tinlake-ui/utils/usePortfolio.ts
+++ b/tinlake-ui/utils/usePortfolio.ts
@@ -22,6 +22,7 @@ export interface TokenBalance {
   price: BN
   value: BN
   balance: BN
+  tranche: Tranche
 }
 
 export interface PortfolioData {
@@ -111,7 +112,7 @@ async function getPortfolio(ipfsPools: IpfsPools, address: string) {
     return {
       id: tokenId,
       symbol: tokenResult.symbol,
-      tranche,
+      tranche: tranche as Tranche,
       price: newPrice,
       value: newValue,
       balance: newBalance,

--- a/tinlake-ui/utils/usePortfolio.ts
+++ b/tinlake-ui/utils/usePortfolio.ts
@@ -98,6 +98,13 @@ async function getPortfolio(ipfsPools: IpfsPools, address: string) {
   const updatesPerToken = await multicall<{ [key: string]: TokenResult }>(calls)
 
   const tokenBalances = Object.entries(updatesPerToken).map(([tokenId, tokenResult]) => {
+    console.log(tokenId)
+    let tranche = Tranche.senior
+    ipfsPools.active.flatMap((pool) => {
+      if (tokenId === pool.addresses.JUNIOR_TOKEN) {
+        tranche = Tranche.junior
+      }
+    })
     const newBalance = new BN(tokenResult.balance).add(new BN(tokenResult.payoutTokenAmount))
     const newPrice = new BN(tokenResult.price)
     const newValue = newBalance.mul(newPrice).div(new BN(10).pow(new BN(27)))
@@ -105,6 +112,7 @@ async function getPortfolio(ipfsPools: IpfsPools, address: string) {
     return {
       id: tokenId,
       symbol: tokenResult.symbol,
+      tranche,
       price: newPrice,
       value: newValue,
       balance: newBalance,
@@ -124,4 +132,9 @@ async function getPortfolio(ipfsPools: IpfsPools, address: string) {
     totalValue,
     totalSupplyRemaining,
   }
+}
+
+export enum Tranche {
+  senior = 'SENIOR',
+  junior = 'JUNIOR',
 }


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

<!-- Describe the goal of this pull request and if possible, insight on the implementation choices. -->

This pull request swaps the subgraph out for the newest version which splits the CFG reward rate into two separate reward rates. One for DROP investments and one for TIN investments. This PR also updates the UI accordingly.

<!-- This will link the pull request to a Github issue. Remove if there is no corresponding Github issue. -->

Closes #<issue-number>

### Approvals

<!-- Depending on the nature of the pull request, remove the roles that are not necessary for this review. Intricate technical changes may require two dev approvals. Reviewers should check the corresponding box after they approve. -->

- [ ] Dev

### Screenshots

![image](https://user-images.githubusercontent.com/6720265/150221873-0a2f9961-22c2-461b-b3df-c276d30b1c85.png)

