### PR TITLE
fix(tinlake-ui): show more than 100 assets on assets page

### DIFF
--- a/tinlake-ui/services/apollo/index.ts
+++ b/tinlake-ui/services/apollo/index.ts
@@ -294,40 +294,36 @@ class Apollo {
     const result = await this.client.query({
       query: gql`
         {
-          pools (where : {id: "${root.toLowerCase()}"}){
+          loans (first: 1000, where: { pool_in: ["${root.toLowerCase()}"]}) {
             id
-            loans (first: 1000) {
+            pool {
               id
-              pool {
-                id
-              }
-              index
-              owner
-              opened
-              closed
-              debt
-              interestRatePerSecond
-              ceiling
-              threshold
-              borrowsCount
-              borrowsAggregatedAmount
-              repaysCount
-              repaysAggregatedAmount
-              nftId
-              nftRegistry
-              maturityDate
-              financingDate
-              riskGroup
             }
+            index
+            owner
+            opened
+            closed
+            debt
+            interestRatePerSecond
+            ceiling
+            threshold
+            borrowsCount
+            borrowsAggregatedAmount
+            repaysCount
+            repaysAggregatedAmount
+            nftId
+            nftRegistry
+            maturityDate
+            financingDate
+            riskGroup
           }
         }
         `,
     })
 
-    if (!result.data?.pools) return { data: [] }
+    if (!result.data?.loans) return { data: [] }
 
-    const pool = result.data.pools[0]
-    const tinlakeLoans = pool ? toTinlakeLoans(pool.loans) : { data: [] }
+    const tinlakeLoans = toTinlakeLoans(result.data.loans)
     return tinlakeLoans
   }
 


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

<!-- Describe the goal of this pull request and if possible, insight on the implementation choices. -->

This pull request fixes the assets page to show more than 100 assets.

The fix is a change to the GraphQL query

<!-- This will link the pull request to a Github issue. Remove if there is no corresponding Github issue. -->


### Approvals

<!-- Depending on the nature of the pull request, remove the roles that are not necessary for this review. Intricate technical changes may require two dev approvals. Reviewers should check the corresponding box after they approve. -->

- [ ] Dev

### Screenshots
![Screenshot 2022-02-15 at 16 31 01](https://user-images.githubusercontent.com/8630331/154094385-2a7ee928-27f2-40e1-bb52-b756686ac3b4.png)


### Impact

