### PR TITLE
30d DROP yields only displayed after 90d

### DIFF
--- a/tinlake-ui/utils/hooks.ts
+++ b/tinlake-ui/utils/hooks.ts
@@ -26,17 +26,24 @@ export const useInterval = (callback: any, delay?: number | null) => {
   }, [delay])
 }
 
-export const useTrancheYield = (poolId?: string | undefined) => {
+type TrancheYield = {
+  dropYield: string
+  tinYield: string
+}
+
+export const useTrancheYield = (poolId?: string | undefined): TrancheYield => {
   const pools = usePools()
 
   return React.useMemo(() => {
     if (pools.data?.pools && poolId) {
       const poolData = pools.data.pools.find((singlePool) => singlePool.id.toLowerCase() === poolId.toLowerCase())
-      if (poolData?.seniorYield30Days && poolData?.juniorYield90Days) {
-        return {
-          dropYield: toPrecision(baseToDisplay(poolData.seniorYield30Days.muln(100), 27), 2),
-          tinYield: toPrecision(baseToDisplay(poolData.juniorYield90Days.muln(100), 27), 2),
-        }
+      return {
+        dropYield: poolData?.seniorYield30Days
+          ? toPrecision(baseToDisplay(poolData.seniorYield30Days.muln(100), 27), 2)
+          : '',
+        tinYield: poolData?.juniorYield90Days
+          ? toPrecision(baseToDisplay(poolData.juniorYield90Days.muln(100), 27), 2)
+          : '',
       }
     }
 


### PR DESCRIPTION

<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

<!-- Describe the goal of this pull request and if possible, insight on the implementation choices. -->

This pull request allows the 30d DROP value to be shown when available, instead of waiting for the TIN 90d value to be available too

<!-- This will link the pull request to a Github issue. Remove if there is no corresponding Github issue. -->

Closes #589 

### Approvals

<!-- Depending on the nature of the pull request, remove the roles that are not necessary for this review. Intricate technical changes may require two dev approvals. Reviewers should check the corresponding box after they approve. -->

- [ ] Dev
- [ ] Dev


