### PR TITLE
Transaction toasts changes

### DIFF
--- a/fabric/src/components/Toast/index.tsx
+++ b/fabric/src/components/Toast/index.tsx
@@ -20,6 +20,7 @@ export type ToastProps = {
   label: string
   sublabel?: string
   onDismiss?: () => void
+  onStatusChange?: (status: ToastStatus) => void
   action?: React.ReactElement
 }
 
@@ -53,8 +54,18 @@ const statusColors = {
   critical: 'statusCritical',
 }
 
-export const Toast: React.FC<ToastProps> = ({ status = 'info', label, sublabel, onDismiss, action }) => {
+export const Toast: React.FC<ToastProps> = ({
+  status = 'info',
+  label,
+  sublabel,
+  onDismiss,
+  onStatusChange,
+  action,
+}) => {
   const Icon = statusIcons[status]
+  React.useEffect(() => {
+    onStatusChange && onStatusChange(status)
+  }, [status, onStatusChange])
   return (
     <Card variant="overlay">
       <Shelf gap={2} px={2} py={1}>


### PR DESCRIPTION

<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

<!-- Describe the goal of this pull request and if possible, insight on the implementation choices. -->

This pull request introduces 2 changes:
- The transaction toasts will be shown only after signing / canceling the transaction (pending / success / fail)
- The success / failure toasts will dismiss automatically after 5 secs

<!-- This will link the pull request to a Github issue. Remove if there is no corresponding Github issue. -->

Closes #655

### Approvals

<!-- Depending on the nature of the pull request, remove the roles that are not necessary for this review. Intricate technical changes may require two dev approvals. Reviewers should check the corresponding box after they approve. -->

- [ ] Dev
- [ ] Dev
- [ ] Designer
- [ ] Product
