### PR TITLE
NFT Studio: Styling tweaks

### DIFF
--- a/fabric/src/components/Card/index.ts
+++ b/fabric/src/components/Card/index.ts
@@ -17,12 +17,9 @@ export const Card = styled(Box)<Props>(({ variant = 'default' }) =>
     borderStyle: 'solid',
     borderColor: 'borderSecondary',
     boxShadow: variant === 'interactive' ? 'cardInteractive' : variant === 'overlay' ? 'cardOverlay' : undefined,
+    transition: 'box-shadow 100ms ease',
 
-    'a:focus-visible &, button:focus-visible &, &:focus-visible': {
-      boxShadow: 'buttonFocused',
-    },
-
-    '&:hover': {
+    'a:focus-visible &, button:focus-visible &, &:focus-visible, a:hover &, button:hover &, a&:hover, button&:hover': {
       boxShadow: variant === 'interactive' ? 'buttonFocused' : undefined,
     },
   })

--- a/fabric/src/theme/tokens/modeDark.ts
+++ b/fabric/src/theme/tokens/modeDark.ts
@@ -9,6 +9,7 @@ const grayScale = {
   gray700: '#616161',
   gray800: '#424242',
   gray900: '#212121',
+  gray950: '#171717',
 }
 
 const statusDefault = grayScale.gray600
@@ -25,7 +26,7 @@ const darkColors = {
   backgroundPrimary: grayScale.gray900,
   backgroundSecondary: grayScale.gray800,
   backgroundPage: 'black',
-  backgroundInput: 'black',
+  backgroundInput: grayScale.gray950,
 
   borderPrimary: grayScale.gray700,
   borderSecondary: grayScale.gray800,

--- a/fabric/src/theme/tokens/modeLight.ts
+++ b/fabric/src/theme/tokens/modeLight.ts
@@ -9,6 +9,7 @@ const grayScale = {
   gray700: '#616161',
   gray800: '#424242',
   gray900: '#212121',
+  gray950: '#171717',
 }
 
 const statusDefault = grayScale.gray600

--- a/nft-studio/lambda/pinCollectionMetadata.js
+++ b/nft-studio/lambda/pinCollectionMetadata.js
@@ -3,10 +3,16 @@ import { ipfsHashToURI, pinFile, pinJson, unpinFile } from './pinata/api'
 
 const fs = require('fs')
 
+const MAX_FILE_SIZE_IN_BYTES = 1024 ** 2 // 1 MB limit
+
 const dataUriToReadStream = ({ tempFilePath, fileDataUri }) => {
   const base64String = fileDataUri.replace(/.+;base64,/, '')
 
-  fs.writeFileSync(tempFilePath, base64String, { encoding: 'base64' })
+  const buffer = Buffer.from(base64String, 'base64')
+
+  if (buffer.byteLength > MAX_FILE_SIZE_IN_BYTES) throw new Error('File too large')
+
+  fs.writeFileSync(tempFilePath, buffer)
 
   console.log(`Temp file '${tempFilePath}' created`)
 

--- a/nft-studio/lambda/pinFileWithMetadata.js
+++ b/nft-studio/lambda/pinFileWithMetadata.js
@@ -3,10 +3,16 @@ import { pinFile, pinJson, unpinFile } from './pinata/api'
 
 const fs = require('fs')
 
+const MAX_FILE_SIZE_IN_BYTES = 1024 ** 2 // 1 MB limit
+
 const dataUriToReadStream = ({ tempFilePath, fileDataUri }) => {
   const base64String = fileDataUri.replace(/.+;base64,/, '')
 
-  fs.writeFileSync(tempFilePath, base64String, { encoding: 'base64' })
+  const buffer = Buffer.from(base64String, 'base64')
+
+  if (buffer.byteLength > MAX_FILE_SIZE_IN_BYTES) throw new Error('File too large')
+
+  fs.writeFileSync(tempFilePath, buffer)
 
   console.log(`Temp file '${tempFilePath}' created`)
 

--- a/nft-studio/src/components/CollectionCard.tsx
+++ b/nft-studio/src/components/CollectionCard.tsx
@@ -6,15 +6,25 @@ import styled from 'styled-components'
 import { collectionMetadataSchema } from '../schemas'
 import { parseMetadataUrl } from '../utils/parseMetadataUrl'
 import { useMetadata } from '../utils/useMetadata'
+import { useVisibilityChecker } from '../utils/useVisibilityChecker'
 import { Identity } from './Identity'
 import { LogoAltair } from './LogoAltair'
+import { TextWithPlaceholder } from './TextWithPlaceholder'
 
 type Props = {
   collection: Collection
 }
 
 export const CollectionCard: React.FC<Props> = ({ collection }) => {
-  const { data: metadata } = useMetadata(collection.metadataUri, collectionMetadataSchema)
+  const [visible, setVisible] = React.useState(false)
+  const ref = React.useRef<HTMLAnchorElement>(null)
+
+  useVisibilityChecker({ ref, onEnterOnce: () => setVisible(true), marginTop: 200 })
+
+  const { data: metadata, isLoading } = useMetadata(
+    visible ? collection.metadataUri : undefined,
+    collectionMetadataSchema
+  )
   const { id, admin, instances } = collection
 
   return (
@@ -30,6 +40,8 @@ export const CollectionCard: React.FC<Props> = ({ collection }) => {
       description={metadata?.description}
       image={metadata?.image}
       count={instances}
+      isLoading={isLoading}
+      ref={ref}
     />
   )
 }
@@ -41,85 +53,97 @@ type InnerProps = {
   label?: React.ReactNode
   description?: string
   image?: string
+  isLoading?: boolean
 }
 
-export const CollectionCardInner: React.FC<InnerProps> = ({ count, to, title, label, description, image }) => {
-  const [imageShown, setImageShown] = React.useState(false)
+export const CollectionCardInner = React.forwardRef<HTMLAnchorElement, InnerProps>(
+  ({ isLoading, count, to, title, label, description, image }, ref) => {
+    const [imageShown, setImageShown] = React.useState(false)
 
-  return (
-    <Card as={Link} display="block" height="100%" to={to} variant="interactive">
-      <Stack>
-        <Box
-          bg="placeholderBackground"
-          style={{ aspectRatio: '16/9' }}
-          borderTopLeftRadius="card"
-          borderTopRightRadius="card"
-          overflow="hidden"
-          position="relative"
-        >
-          {image && (
-            <Box
-              as="img"
-              alt=""
-              src={parseMetadataUrl(image)}
-              display="block"
+    return (
+      <Card as={Link} display="block" height="100%" to={to} variant="interactive" ref={ref}>
+        <Stack>
+          <Box
+            bg="placeholderBackground"
+            style={{ aspectRatio: '16/9' }}
+            borderTopLeftRadius="card"
+            borderTopRightRadius="card"
+            overflow="hidden"
+            position="relative"
+          >
+            {image && (
+              <Box
+                as="img"
+                alt=""
+                src={parseMetadataUrl(image)}
+                display="block"
+                width="100%"
+                height="100%"
+                position="relative"
+                zIndex={1}
+                style={{ objectFit: 'cover', transition: 'opacity 200ms', opacity: imageShown ? 1 : 0 }}
+                onLoad={() => setImageShown(true)}
+              />
+            )}
+            <Shelf
+              justifyContent="center"
+              position="absolute"
               width="100%"
               height="100%"
-              position="relative"
-              zIndex={1}
-              style={{ objectFit: 'cover', transition: 'opacity 200ms', opacity: imageShown ? 1 : 0 }}
-              onLoad={() => setImageShown(true)}
-            />
-          )}
-          <Shelf
-            justifyContent="center"
-            position="absolute"
-            width="100%"
-            height="100%"
-            top={0}
-            left={0}
-            zIndex={0}
-            backgroundColor="black"
-          >
-            <LogoAltair height="50%" />
-          </Shelf>
+              top={0}
+              left={0}
+              zIndex={0}
+              backgroundColor="black"
+            >
+              <LogoAltair height="50%" />
+            </Shelf>
 
-          {count != null ? (
-            <Count px={1} py="4px" position="absolute" bottom={1} right={1} zIndex={1}>
-              <Text variant="label2" color="textPrimary">
-                {count} NFTs
-              </Text>
-            </Count>
-          ) : null}
-        </Box>
-        <Stack gap={2} py={[2, 3]} px={[3, 4]} alignItems="center">
-          <Stack alignItems="center">
-            <Text as="h2" variant="heading2" textAlign="center" style={{ wordBreak: 'break-word' }}>
-              {title}
-            </Text>
-            {label && (
-              <Text textAlign="center" variant="label1">
-                {label}
-              </Text>
-            )}
+            {count != null ? (
+              <Count px={1} py="4px" position="absolute" bottom={1} right={1} zIndex={1}>
+                <Text variant="label2" color="textPrimary">
+                  {count} NFTs
+                </Text>
+              </Count>
+            ) : null}
+          </Box>
+          <Stack gap={2} py={[2, 3]} px={[3, 4]} alignItems="center">
+            <Stack alignItems="center">
+              <TextWithPlaceholder
+                isLoading={isLoading}
+                as="h2"
+                variant="heading2"
+                textAlign="center"
+                style={{ wordBreak: 'break-word' }}
+              >
+                {title}
+              </TextWithPlaceholder>
+              {label && (
+                <Text textAlign="center" variant="label1">
+                  {label}
+                </Text>
+              )}
+            </Stack>
+            <TextWithPlaceholder
+              isLoading={isLoading}
+              width={70}
+              variance={20}
+              textAlign="center"
+              style={{
+                overflow: 'hidden',
+                display: '-webkit-box',
+                WebkitLineClamp: 3,
+                WebkitBoxOrient: 'vertical',
+                wordBreak: 'break-word',
+              }}
+            >
+              {description}
+            </TextWithPlaceholder>
           </Stack>
-          <Text
-            textAlign="center"
-            style={{
-              overflow: 'hidden',
-              display: '-webkit-box',
-              WebkitLineClamp: 3,
-              WebkitBoxOrient: 'vertical',
-              wordBreak: 'break-word',
-            }}
-          >
-            {description}
-          </Text>
         </Stack>
-      </Stack>
-    </Card>
-  )
-}
+      </Card>
+    )
+  }
+)
 
 const Count = styled(Box)`
   &::before {
@@ -130,7 +154,7 @@ const Count = styled(Box)`
     left: 0;
     top: 0;
     background-color: ${({ theme }) => theme.colors.backgroundSecondary};
-    opacity: 0.9;
+    opacity: 0.8;
     z-index: -1;
     border-radius: 2px;
   }

--- a/nft-studio/src/components/CreateCollectionDialog.tsx
+++ b/nft-studio/src/components/CreateCollectionDialog.tsx
@@ -17,7 +17,7 @@ import { useCentrifuge } from './CentrifugeProvider'
 // TODO: replace with better fee estimate
 const CREATE_FEE_ESTIMATE = 2
 
-const MAX_FILE_SIZE_IN_BYTES = 1024 ** 2 // 1 mb limit by default
+const MAX_FILE_SIZE_IN_BYTES = 10 * 1024 ** 2 // 1 MB limit by default
 const isImageFile = (file: File): boolean => !!file.type.match(/^image\//)
 
 export const CreateCollectionDialog: React.FC<{ open: boolean; onClose: () => void }> = ({ open, onClose }) => {

--- a/nft-studio/src/components/CreateCollectionDialog.tsx
+++ b/nft-studio/src/components/CreateCollectionDialog.tsx
@@ -129,7 +129,7 @@ export const CreateCollectionDialog: React.FC<{ open: boolean; onClose: () => vo
             disabled={fieldDisabled}
           />
           <FileUpload
-            label="Upload collection logo (JPEG, SVG, PNG, or GIF up to 1 MB)"
+            label="Collection logo (JPEG, SVG, PNG, or GIF up to 1 MB)"
             placeholder="Add file"
             onFileUpdate={(file) => setLogo(file)}
             onFileCleared={() => setLogo(null)}

--- a/nft-studio/src/components/NFTCard.tsx
+++ b/nft-studio/src/components/NFTCard.tsx
@@ -6,21 +6,33 @@ import { nftMetadataSchema } from '../schemas'
 import { parseMetadataUrl } from '../utils/parseMetadataUrl'
 import { useCollection } from '../utils/useCollections'
 import { useMetadata } from '../utils/useMetadata'
+import { useVisibilityChecker } from '../utils/useVisibilityChecker'
 import { useCentrifuge } from './CentrifugeProvider'
 import { Identity } from './Identity'
+import { TextWithPlaceholder } from './TextWithPlaceholder'
 
 type Props = {
   nft: NFT
 }
 
 export const NFTCard: React.FC<Props> = ({ nft }) => {
-  const { data: metadata } = useMetadata(nft?.metadataUri, nftMetadataSchema)
+  const [visible, setVisible] = React.useState(false)
+  const ref = React.useRef<HTMLAnchorElement>(null)
+
+  useVisibilityChecker({ ref, onEnterOnce: () => setVisible(true), marginTop: 200 })
+
+  const { data: metadata, isLoading: metadataIsLoading } = useMetadata(
+    visible ? nft.metadataUri : undefined,
+    nftMetadataSchema
+  )
   const collection = useCollection(nft.collectionId)
   const centrifuge = useCentrifuge()
   const [imageShown, setImageShown] = React.useState(false)
 
+  const isLoading = !visible || metadataIsLoading
+
   return (
-    <Card as={Link} to={`/collection/${nft.collectionId}/object/${nft.id}`} variant="interactive" pb={[3, 4]}>
+    <Card as={Link} to={`/collection/${nft.collectionId}/object/${nft.id}`} variant="interactive" pb={[3, 4]} ref={ref}>
       <Stack gap={[2, 3]}>
         <Box
           bg="placeholderBackground"
@@ -43,9 +55,9 @@ export const NFTCard: React.FC<Props> = ({ nft }) => {
           )}
         </Box>
         <Stack gap={1} px={[2, 3]}>
-          <Text as="h2" variant="heading2" style={{ wordBreak: 'break-word' }}>
+          <TextWithPlaceholder isLoading={isLoading} as="h2" variant="heading2" style={{ wordBreak: 'break-word' }}>
             {metadata?.name ?? 'Unnamed NFT'}
-          </Text>
+          </TextWithPlaceholder>
           <Shelf flexWrap="wrap" gap={1}>
             {collection?.owner && (
               <Box flexBasis="150px" mr="auto">

--- a/nft-studio/src/components/TextWithPlaceholder.tsx
+++ b/nft-studio/src/components/TextWithPlaceholder.tsx
@@ -1,0 +1,91 @@
+import { Box, Text, TextProps } from '@centrifuge/fabric'
+import * as React from 'react'
+import styled, { css, keyframes } from 'styled-components'
+
+const load = keyframes`
+  from {
+	  background-position-x: 0;
+  }
+  to {
+	  background-position-x: -200%;
+  }
+`
+
+const Loading = styled(Box)<{ $isLoading: boolean }>`
+ display: inline;
+ --color1: ${({ theme }) => theme.colors.borderPrimary};
+ --color2: ${({ theme }) => theme.colors.borderSecondary};
+ background: linear-gradient(
+   90deg,
+	 var(--color1),
+	 var(--color2),
+	 var(--color1)
+   );
+   background-size: 200% 80%;
+   background-position-y: 50%;
+   background-repeat: repeat-x;
+   border-radius: .4em;
+   -webkit-box-decoration-break: clone;
+   box-decoration-break: clone;
+   word-break: break-word;
+   animation: ${load} 1.5s ease infinite;
+}
+`
+
+const LoadingWrapper = styled.div<{ $lines: number; $isLoading: boolean }>`
+  ${({ $lines, $isLoading }) =>
+    $isLoading &&
+    css`
+      display: -webkit-box;
+      -webkit-line-clamp: ${$lines};
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      color: transparent;
+      -webkit-box-decoration-break: clone;
+      box-decoration-break: clone;
+    `};
+`
+
+type Props = TextProps & {
+  words?: number
+  maxLines?: number
+  variance?: number
+  width?: number
+  isLoading?: boolean
+}
+
+export const TextWithPlaceholder: React.FC<Props> = ({
+  words = 1,
+  maxLines = 3,
+  variance = 2,
+  width = 10,
+  isLoading,
+  children,
+  ...textProps
+}) => {
+  const [rand] = React.useState(() => Math.random())
+  return (
+    <Text {...textProps} underline={isLoading ? undefined : textProps.underline}>
+      {isLoading ? (
+        <LoadingWrapper $lines={maxLines} $isLoading={isLoading}>
+          {Array.from({ length: words }, (_, i) => (
+            <React.Fragment key={i}>
+              <Text as={Loading}>{getWord(width + Math.round((((rand * 10 ** i) % 1) - 0.5) * variance * 2))}</Text>{' '}
+            </React.Fragment>
+          ))}
+        </LoadingWrapper>
+      ) : (
+        children
+      )}
+    </Text>
+  )
+}
+
+function getWord(width: number) {
+  const word = Array.from({ length: Math.max(3, width) }, () => '0').join('')
+
+  if (word.length < 16) return word
+
+  return `${word.slice(0, -8)} ${word.slice(-8)}` // Push more characters to a new line if the word wraps, to avoid having a tiny bit of placeholder on a line
+}

--- a/nft-studio/src/components/VisibilityChecker.tsx
+++ b/nft-studio/src/components/VisibilityChecker.tsx
@@ -3,9 +3,9 @@ import { Options as UseVisibilityCheckerOptions, useVisibilityChecker } from '..
 
 type Props = Omit<UseVisibilityCheckerOptions, 'ref'>
 
-export const VisibilityChecker: React.FC<Props> = (visibilityCheckerOptions) => {
+export const VisibilityChecker: React.FC<Props> = ({ children, ...visibilityCheckerOptions }) => {
   const ref = React.useRef<HTMLDivElement>(null)
   useVisibilityChecker({ ref, ...visibilityCheckerOptions })
 
-  return <div ref={ref} />
+  return <div ref={ref}>{children}</div>
 }

--- a/nft-studio/src/pages/Collection.tsx
+++ b/nft-studio/src/pages/Collection.tsx
@@ -10,6 +10,7 @@ import { PageHeader } from '../components/PageHeader'
 import { AnchorPillButton } from '../components/PillButton'
 import { RouterLinkButton } from '../components/RouterLinkButton'
 import { PageWithSideBar } from '../components/shared/PageWithSideBar'
+import { TextWithPlaceholder } from '../components/TextWithPlaceholder'
 import { VisibilityChecker } from '../components/VisibilityChecker'
 import { useWeb3 } from '../components/Web3Provider'
 import { collectionMetadataSchema } from '../schemas'
@@ -35,7 +36,7 @@ const Collection: React.FC = () => {
   } = useRouteMatch<{ cid: string }>()
   const { selectedAccount } = useWeb3()
   const collection = useCollection(collectionId)
-  const { data: metadata } = useMetadata(collection?.metadataUri, collectionMetadataSchema)
+  const { data: metadata, isLoading } = useMetadata(collection?.metadataUri, collectionMetadataSchema)
   const { data: nfts } = useNFTs(collectionId)
   const [shownCount, setShownCount] = React.useState(COUNT_PER_PAGE)
   const centrifuge = useCentrifuge()
@@ -83,20 +84,29 @@ const Collection: React.FC = () => {
           />
         ) : (
           <Shelf
-            backgroundColor="textPrimary"
+            backgroundColor="black"
             display="flex"
             width="144px"
             height="144px"
             justifyContent="center"
             borderRadius="50%"
+            borderWidth={1}
+            borderStyle="solid"
+            borderColor="borderPrimary"
           >
             <LogoAltair width="100px" />
           </Shelf>
         )}
         <Stack alignItems="center" gap="4px">
-          <Text variant="heading1" fontSize="36px" textAlign="center" style={{ wordBreak: 'break-word' }}>
+          <TextWithPlaceholder
+            isLoading={isLoading}
+            variant="heading1"
+            fontSize="36px"
+            textAlign="center"
+            style={{ wordBreak: 'break-word' }}
+          >
             {metadata?.name || 'Unnamed collection'}
-          </Text>
+          </TextWithPlaceholder>
           <Shelf gap={1} alignItems="baseline" flexWrap="wrap">
             <Box mx="auto">
               <Text variant="body2">by</Text>
@@ -110,23 +120,24 @@ const Collection: React.FC = () => {
           </Shelf>
         </Stack>
 
-        {metadata?.description && (
-          <Box maxWidth="680px">
-            <Text
-              variant="body1"
-              textAlign="center"
-              style={{
-                overflow: 'hidden',
-                display: '-webkit-box',
-                WebkitLineClamp: 10,
-                WebkitBoxOrient: 'vertical',
-                wordBreak: 'break-word',
-              }}
-            >
-              {metadata?.description || ''}
-            </Text>
-          </Box>
-        )}
+        <Box maxWidth="680px">
+          <TextWithPlaceholder
+            isLoading={isLoading}
+            width={100}
+            words={1}
+            variant="body1"
+            textAlign="center"
+            style={{
+              overflow: 'hidden',
+              display: '-webkit-box',
+              WebkitLineClamp: 10,
+              WebkitBoxOrient: 'vertical',
+              wordBreak: 'break-word',
+            }}
+          >
+            {metadata?.description || ''}
+          </TextWithPlaceholder>
+        </Box>
       </Stack>
       {nfts?.length ? (
         <>

--- a/nft-studio/src/pages/MintNFT.tsx
+++ b/nft-studio/src/pages/MintNFT.tsx
@@ -1,16 +1,15 @@
-import { Box, Button, IconArrowLeft, Shelf, Stack, Text } from '@centrifuge/fabric'
+import { Box, Button, IconArrowLeft, Shelf, Stack, Text, TextAreaInput, TextInput } from '@centrifuge/fabric'
 import { Flex } from '@centrifuge/fabric/dist/components/Flex'
 import React, { useReducer, useState } from 'react'
 import { useQueryClient } from 'react-query'
 import { useHistory, useParams } from 'react-router'
+import { NavLink } from 'react-router-dom'
 import { useCentrifuge } from '../components/CentrifugeProvider'
 import { FileImageUpload } from '../components/FileImageUpload'
 import { PageHeader } from '../components/PageHeader'
 import { RouterLinkButton } from '../components/RouterLinkButton'
 import { PageWithSideBar } from '../components/shared/PageWithSideBar'
 import { SplitView } from '../components/SplitView'
-import { TextArea } from '../components/TextArea'
-import { TextInput } from '../components/TextInput'
 import { nftMetadataSchema } from '../schemas'
 import { createNFTMetadata } from '../utils/createNFTMetadata'
 import { getFileDataURI } from '../utils/getFileDataURI'
@@ -154,7 +153,17 @@ const MintNFT: React.FC = () => {
         }
         right={
           <Box px={[2, 4, 8]} py={9}>
-            <Stack>
+            <Stack gap={6}>
+              <Stack gap={1}>
+                <NavLink to={`/collection/${collectionId}`}>
+                  <Text variant="heading3" underline>
+                    {collectionMetadata?.name}
+                  </Text>
+                </NavLink>
+                <Text variant="heading1" fontSize="36px" fontWeight="700" mb="4px">
+                  {nftName || 'Untitled NFT'}
+                </Text>
+              </Stack>
               <form onSubmit={execute} action="">
                 <Box mb={3}>
                   <TextInput
@@ -168,7 +177,7 @@ const MintNFT: React.FC = () => {
                     disabled={fieldDisabled}
                   />
                 </Box>
-                <TextArea
+                <TextAreaInput
                   label="Description"
                   value={nftDescription}
                   maxLength={nftMetadataSchema.description.maxLength}

--- a/nft-studio/src/pages/MintNFT.tsx
+++ b/nft-studio/src/pages/MintNFT.tsx
@@ -156,11 +156,11 @@ const MintNFT: React.FC = () => {
             <Stack gap={6}>
               <Stack gap={1}>
                 <NavLink to={`/collection/${collectionId}`}>
-                  <Text variant="heading3" underline>
+                  <Text variant="heading3" underline style={{ wordBreak: 'break-word' }}>
                     {collectionMetadata?.name}
                   </Text>
                 </NavLink>
-                <Text variant="heading1" fontSize="36px" fontWeight="700" mb="4px">
+                <Text variant="heading1" fontSize="36px" fontWeight="700" mb="4px" style={{ wordBreak: 'break-word' }}>
                   {nftName || 'Untitled NFT'}
                 </Text>
               </Stack>

--- a/nft-studio/src/pages/NFT.tsx
+++ b/nft-studio/src/pages/NFT.tsx
@@ -159,7 +159,7 @@ const NFT: React.FC = () => {
                   maxWidth={800}
                   style={{ aspectRatio: '1 / 1' }}
                 >
-                  <Box as="img" maxWidth={800} src={imageUrl} />
+                  <Box as="img" maxWidth="100%" src={imageUrl} />
                 </Box>
               ) : (
                 <Box
@@ -232,14 +232,21 @@ const NFT: React.FC = () => {
                         href={`${process.env.REACT_APP_SUBSCAN_URL}/account/${nft.owner}`}
                         target="_blank"
                       >
-                        <Identity address={collection.owner} clickToCopy />
+                        <Identity address={collection.owner} />
                       </AnchorPillButton>
                     </Shelf>
                   </Stack>
 
                   <Stack gap={1}>
                     <Text variant="label1">Description</Text>
-                    <TextWithPlaceholder isLoading={isLoading} variant="body2" style={{ wordBreak: 'break-word' }}>
+                    <TextWithPlaceholder
+                      isLoading={isLoading}
+                      words={2}
+                      width={80}
+                      variance={30}
+                      variant="body2"
+                      style={{ wordBreak: 'break-word' }}
+                    >
                       {nftMetadata?.description || 'No description'}
                     </TextWithPlaceholder>
                   </Stack>

--- a/nft-studio/src/pages/NFT.tsx
+++ b/nft-studio/src/pages/NFT.tsx
@@ -11,6 +11,7 @@ import { RouterLinkButton } from '../components/RouterLinkButton'
 import { SellDialog } from '../components/SellDialog'
 import { PageWithSideBar } from '../components/shared/PageWithSideBar'
 import { SplitView } from '../components/SplitView'
+import { TextWithPlaceholder } from '../components/TextWithPlaceholder'
 import { TransferDialog } from '../components/TransferDialog'
 import { nftMetadataSchema } from '../schemas'
 import { parseMetadataUrl } from '../utils/parseMetadataUrl'
@@ -35,9 +36,9 @@ const NFT: React.FC = () => {
   const address = useAddress()
   const { data: permissions } = usePermissions(address)
   const nft = useNFT(collectionId, nftId)
-  const { data: nftMetadata } = useMetadata(nft?.metadataUri, nftMetadataSchema)
+  const { data: nftMetadata, isLoading } = useMetadata(nft?.metadataUri, nftMetadataSchema)
   const collection = useCollection(collectionId)
-  const { data: collectionMetadata } = useCollectionMetadata(collection?.id)
+  const { data: collectionMetadata, isLoading: isCollectionMetadataLoading } = useCollectionMetadata(collection?.id)
   const [transferOpen, setTransferOpen] = React.useState(false)
   const [sellOpen, setSellOpen] = React.useState(false)
   const [buyOpen, setBuyOpen] = React.useState(false)
@@ -51,7 +52,7 @@ const NFT: React.FC = () => {
     !isLoanCollection && permissions && Object.values(permissions).some((p) => p.roles.includes('Borrower'))
 
   return (
-    <Stack gap={8} flex={1}>
+    <Stack flex={1}>
       <Box>
         <PageHeader
           parent={{ label: collectionMetadata?.name ?? 'Collection', to: `/collection/${collectionId}` }}
@@ -140,35 +141,46 @@ const NFT: React.FC = () => {
             </>
           }
         />
-        <Box mt={1}>
-          <RouterLinkButton icon={IconArrowLeft} to="/nfts" variant="text">
-            Back
-          </RouterLinkButton>
-        </Box>
       </Box>
       <SplitView
         left={
-          <Box display="flex" alignItems="center" justifyContent="center" py={8} height="100%">
-            {imageUrl ? (
-              <Box as="img" maxHeight="80vh" src={imageUrl} />
-            ) : (
-              <Box
-                bg="borderSecondary"
-                display="flex"
-                alignItems="center"
-                justifyContent="center"
-                maxHeight="60vh"
-                maxWidth="60vh"
-                borderRadius="10px"
-                style={{ aspectRatio: '1 / 1' }}
-              >
-                <IconNft color="backgroundPrimary" size="50%" />
-              </Box>
-            )}
+          <Box>
+            <Box mt={1}>
+              <RouterLinkButton icon={IconArrowLeft} to="/nfts" variant="text">
+                Back
+              </RouterLinkButton>
+            </Box>
+            <Box display="flex" alignItems="center" justifyContent="center" py={2} height="100%">
+              {imageUrl ? (
+                <Box
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="center"
+                  maxWidth={800}
+                  style={{ aspectRatio: '1 / 1' }}
+                >
+                  <Box as="img" maxWidth={800} src={imageUrl} />
+                </Box>
+              ) : (
+                <Box
+                  bg="borderSecondary"
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="center"
+                  // maxHeight="60vh"
+                  maxWidth={800}
+                  borderRadius="10px"
+                  style={{ aspectRatio: '1 / 1' }}
+                >
+                  <IconNft color="backgroundPrimary" size="50%" />
+                </Box>
+              )}
+            </Box>
           </Box>
         }
         right={
           <Shelf
+            pt={8}
             px={[2, 4, 8]}
             gap={[4, 4, 8]}
             alignItems="flex-start"
@@ -199,13 +211,19 @@ const NFT: React.FC = () => {
 
                   <Stack gap={1} mb={6}>
                     <NavLink to={`/collection/${collectionId}`}>
-                      <Text variant="heading3" underline>
+                      <TextWithPlaceholder isLoading={isCollectionMetadataLoading} variant="heading3" underline>
                         {collectionMetadata?.name}
-                      </Text>
+                      </TextWithPlaceholder>
                     </NavLink>
-                    <Text variant="heading1" fontSize="36px" fontWeight="700" mb="4px">
+                    <TextWithPlaceholder
+                      isLoading={isLoading}
+                      variant="heading1"
+                      fontSize="36px"
+                      fontWeight="700"
+                      mb="4px"
+                    >
                       {nftMetadata?.name}
-                    </Text>
+                    </TextWithPlaceholder>
                     <Shelf gap={1}>
                       <Text variant="heading3" color="textSecondary">
                         by
@@ -221,9 +239,9 @@ const NFT: React.FC = () => {
 
                   <Stack gap={1}>
                     <Text variant="label1">Description</Text>
-                    <Text variant="body2" style={{ wordBreak: 'break-word' }}>
+                    <TextWithPlaceholder isLoading={isLoading} variant="body2" style={{ wordBreak: 'break-word' }}>
                       {nftMetadata?.description || 'No description'}
-                    </Text>
+                    </TextWithPlaceholder>
                   </Stack>
 
                   {imageUrl && (


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

* Change input background color
* Fix vertical line on NFT page
* Fix NFT width on NFT page
* Add text placeholders while metadata is loading
* Load metadata in cards on intersection with the viewport
* Tweak NFT count background color in collection card
* Add border around collection logo
* Add title and collection link to Mint NFT page
* Check file size in Netlify functions

### Approvals

<!-- Depending on the nature of the pull request, remove the roles that are not necessary for this review. Intricate technical changes may require two dev approvals. Reviewers should check the corresponding box after they approve. -->

- [ ] Dev
- [ ] Designer

### Screenshots

![Screenshot 2022-03-14 at 11 54 26](https://user-images.githubusercontent.com/23527729/158214836-530b2684-5509-4a1a-b596-f3e207dd4719.png)
![image](https://user-images.githubusercontent.com/23527729/158214909-b9c32fa3-ac38-45ca-a2bb-0f34a26069cb.png)
![image](https://user-images.githubusercontent.com/23527729/158214951-e744fa0c-092f-4faa-9379-91177586de1a.png)
![image](https://user-images.githubusercontent.com/23527729/158216520-262c2e31-c422-482f-8419-bcd8bf475edc.png)
![image](https://user-images.githubusercontent.com/23527729/158216556-2818e6cf-3e84-49ad-a684-26e9842c01b0.png)


### Impact

<!-- Describe what parts of the app were affected so that reviewers can direct their focus. -->
