### PR TITLE
NFT Playground: Save collection logo when switching dialogs

### DIFF
--- a/fabric/src/components/FileUpload/index.tsx
+++ b/fabric/src/components/FileUpload/index.tsx
@@ -5,6 +5,7 @@ import IconAlertCircle from '../../icon/IconAlertCircle'
 import IconPlus from '../../icon/IconPlus'
 import IconSpinner from '../../icon/IconSpinner'
 import IconX from '../../icon/IconX'
+import useControlledState from '../../utils/useControlledState'
 import { Box } from '../Box'
 import { Button } from '../Button'
 import { Flex } from '../Flex'
@@ -103,8 +104,8 @@ const Spinner = styled(IconSpinner)`
 `
 
 type FileUploadProps = {
-  onFileUpdate?: (file: File) => void
-  onFileCleared?: () => void
+  file?: File | null
+  onFileChange?: (file: File | null) => void
   validate?: (file: File) => string | undefined
   errorMessage?: string
   accept?: string
@@ -115,8 +116,8 @@ type FileUploadProps = {
 }
 
 export const FileUpload: React.FC<FileUploadProps> = ({
-  onFileUpdate,
-  onFileCleared,
+  file: fileProp,
+  onFileChange,
   validate,
   errorMessage: errorMessageProp,
   accept,
@@ -126,7 +127,7 @@ export const FileUpload: React.FC<FileUploadProps> = ({
   label,
 }) => {
   const inputRef = useRef<HTMLInputElement>(null)
-  const [curFile, setCurFile] = useState<File | null>(null)
+  const [curFile, setCurFile] = useControlledState<File | null>(null, fileProp, onFileChange)
   const [error, setError] = useState<string | null>(null)
   const [dragOver, setDragOver] = useState(false)
 
@@ -139,7 +140,6 @@ export const FileUpload: React.FC<FileUploadProps> = ({
   function handleClear() {
     setError(null)
     setCurFile(null)
-    onFileCleared?.()
   }
 
   async function handleNewFile(newFile: File) {
@@ -155,7 +155,6 @@ export const FileUpload: React.FC<FileUploadProps> = ({
     }
 
     setCurFile(newFile)
-    onFileUpdate?.(newFile)
   }
 
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {

--- a/fabric/src/components/FileUpload/index.tsx
+++ b/fabric/src/components/FileUpload/index.tsx
@@ -143,6 +143,8 @@ export const FileUpload: React.FC<FileUploadProps> = ({
   }
 
   async function handleNewFile(newFile: File) {
+    setError(null)
+
     if (curFile) {
       handleClear()
     }

--- a/fabric/src/utils/useControlledState.ts
+++ b/fabric/src/utils/useControlledState.ts
@@ -1,0 +1,30 @@
+import { Dispatch, SetStateAction, useState } from 'react'
+import useEventCallback from './useEventCallback'
+import usePrevious from './usePrevious'
+
+function useControlledState<T>(
+  initialUncontrolledValue: T,
+  externalValue?: T,
+  setExternalValue?: Dispatch<SetStateAction<T>>
+) {
+  const [isControlled] = useState(externalValue !== undefined)
+  const [internalValue, setInternalValue] = useState<T>(initialUncontrolledValue)
+
+  if (process.env.NODE_ENV !== 'production') {
+    const wasControlled = usePrevious(externalValue !== undefined) // eslint-disable-line
+    if (wasControlled !== undefined && isControlled !== wasControlled) {
+      // eslint-disable-next-line no-console
+      console.error('useControlledState: Switching between controlled and uncontrolled is not supported')
+    }
+  }
+
+  const value = isControlled ? externalValue : internalValue
+  const setValue = useEventCallback((newValue: SetStateAction<T>) => {
+    if (setExternalValue) setExternalValue(newValue)
+    if (!isControlled) setInternalValue(newValue)
+  })
+
+  return [value, setValue] as const
+}
+
+export default useControlledState

--- a/fabric/src/utils/useEventCallback.ts
+++ b/fabric/src/utils/useEventCallback.ts
@@ -1,0 +1,20 @@
+import { useCallback, useLayoutEffect, useRef } from 'react'
+
+type Calback = (...args: any[]) => any
+
+function useEventCallback<T extends Calback>(callback: T) {
+  const ref = useRef<T>((() => {
+    throw new Error('Cannot call an event handler while rendering.')
+  }) as any)
+
+  useLayoutEffect(() => {
+    ref.current = callback
+  })
+
+  return useCallback((...args: Parameters<T>) => {
+    const fn = ref.current
+    return fn(...args)
+  }, [])
+}
+
+export default useEventCallback

--- a/fabric/src/utils/usePrevious.ts
+++ b/fabric/src/utils/usePrevious.ts
@@ -1,0 +1,11 @@
+import { useEffect, useRef } from 'react'
+
+function usePrevious<T = any>(value: T) {
+  const ref = useRef<T>()
+  useEffect(() => {
+    ref.current = value
+  })
+  return ref.current
+}
+
+export default usePrevious

--- a/nft-studio/public/index.html
+++ b/nft-studio/public/index.html
@@ -11,7 +11,7 @@
     <meta name="msapplication-TileColor" content="#da532c" />
     <meta name="theme-color" content="#ffffff" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="Centrifuge" />
+    <meta name="description" content="Mint and trade NFTs" />
     <style>
       @font-face {
         font-family: 'Inter';
@@ -34,7 +34,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Centrifuge App</title>
+    <title>NFT Playground</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/nft-studio/src/components/CollectionCard.tsx
+++ b/nft-studio/src/components/CollectionCard.tsx
@@ -94,6 +94,7 @@ export const CollectionCardInner = React.forwardRef<HTMLAnchorElement, InnerProp
               left={0}
               zIndex={0}
               backgroundColor="black"
+              style={{ transition: 'opacity 200ms', opacity: imageShown ? 0 : 1 }}
             >
               <LogoAltair height="50%" />
             </Shelf>

--- a/nft-studio/src/components/CreateCollectionDialog.tsx
+++ b/nft-studio/src/components/CreateCollectionDialog.tsx
@@ -113,8 +113,6 @@ export const CreateCollectionDialog: React.FC<{ open: boolean; onClose: () => vo
 
   const confirmDisabled = !termsAccepted
 
-  console.log('file', logo)
-
   return (
     <>
       <Dialog isOpen={open && !confirmOpen} onClose={close}>

--- a/nft-studio/src/components/CreateCollectionDialog.tsx
+++ b/nft-studio/src/components/CreateCollectionDialog.tsx
@@ -17,7 +17,7 @@ import { useCentrifuge } from './CentrifugeProvider'
 // TODO: replace with better fee estimate
 const CREATE_FEE_ESTIMATE = 2
 
-const MAX_FILE_SIZE_IN_BYTES = 10 * 1024 ** 2 // 1 MB limit by default
+const MAX_FILE_SIZE_IN_BYTES = 1024 ** 2 // 1 MB limit by default
 const isImageFile = (file: File): boolean => !!file.type.match(/^image\//)
 
 export const CreateCollectionDialog: React.FC<{ open: boolean; onClose: () => void }> = ({ open, onClose }) => {
@@ -112,6 +112,8 @@ export const CreateCollectionDialog: React.FC<{ open: boolean; onClose: () => vo
   }
 
   const confirmDisabled = !termsAccepted
+
+  console.log('file', logo)
 
   return (
     <>

--- a/nft-studio/src/components/CreateCollectionDialog.tsx
+++ b/nft-studio/src/components/CreateCollectionDialog.tsx
@@ -92,6 +92,7 @@ export const CreateCollectionDialog: React.FC<{ open: boolean; onClose: () => vo
     setDescription('')
     resetLastTransaction()
     resetUpload()
+    setConfirmOpen(false)
     setTermsAccepted(false)
   }
 
@@ -183,7 +184,7 @@ export const CreateCollectionDialog: React.FC<{ open: boolean; onClose: () => vo
                 <Button variant="outlined" onClick={() => setConfirmOpen(false)}>
                   Cancel
                 </Button>
-                <Button type="submit" disabled={confirmDisabled}>
+                <Button type="submit" loading={isTxPending} disabled={confirmDisabled}>
                   Create Collection
                 </Button>
               </ButtonGroup>

--- a/nft-studio/src/components/CreateCollectionDialog.tsx
+++ b/nft-studio/src/components/CreateCollectionDialog.tsx
@@ -137,8 +137,8 @@ export const CreateCollectionDialog: React.FC<{ open: boolean; onClose: () => vo
             <FileUpload
               label="Collection logo (JPEG, SVG, PNG, or GIF up to 1 MB)"
               placeholder="Choose image"
-              onFileUpdate={(file) => setLogo(file)}
-              onFileCleared={() => setLogo(null)}
+              file={logo}
+              onFileChange={(file) => setLogo(file)}
               validate={(file) => {
                 if (!isImageFile(file)) {
                   return 'File format not supported'

--- a/nft-studio/src/pages/MintNFT.tsx
+++ b/nft-studio/src/pages/MintNFT.tsx
@@ -128,7 +128,7 @@ const MintNFT: React.FC = () => {
         left={
           <Box>
             <Box pt={1}>
-              <RouterLinkButton icon={IconArrowLeft} to="/nfts" variant="text">
+              <RouterLinkButton icon={IconArrowLeft} to={`/collection/${collectionId}`} variant="text">
                 Back
               </RouterLinkButton>
             </Box>

--- a/nft-studio/src/pages/NFT.tsx
+++ b/nft-studio/src/pages/NFT.tsx
@@ -146,7 +146,7 @@ const NFT: React.FC = () => {
         left={
           <Box>
             <Box mt={1}>
-              <RouterLinkButton icon={IconArrowLeft} to="/nfts" variant="text">
+              <RouterLinkButton icon={IconArrowLeft} to={`/collection/${collectionId}`} variant="text">
                 Back
               </RouterLinkButton>
             </Box>


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

When in the Create Collection dialog and going to the Terms dialog and back, the collection logo wasn't being saved. Changes the Fabric FileUpload component so that it's state can optionally be controlled via props.

### Approvals

- [x] Dev

### Impact

NFT Playground, Fabric
