### PR TITLE
chore: refactor to use signAndSend

### DIFF
--- a/tinlake-ui/services/centChain/index.ts
+++ b/tinlake-ui/services/centChain/index.ts
@@ -77,7 +77,7 @@ export class CentChain {
     // eslint-disable-next-line no-async-promise-executor
     return new Promise(async (resolve, reject) => {
       const api = await this.api()
-      const extrinsic = api.tx.radClaims.claim(claimerAccountID, amount, proof)
+      const extrinsic = api.tx.claims.claim(claimerAccountID, amount, proof)
       await extrinsic
         .signAndSend(address, { signer: injector.signer }, ({ status, dispatchError }) => {
           // status would still be set, but in the case of error we can shortcut

--- a/tinlake-ui/services/centChain/index.ts
+++ b/tinlake-ui/services/centChain/index.ts
@@ -1,6 +1,7 @@
 import { ApiPromise, WsProvider } from '@polkadot/api'
 import { InjectedAccountWithMeta } from '@polkadot/extension-inject/types'
 import config from '../../config'
+import { accountIdToCentChainAddr } from './accountIdToCentChainAddr'
 import { centChainAddrToAccountId } from './centChainAddrToAccountId'
 import { types } from './types'
 
@@ -66,13 +67,19 @@ export class CentChain {
    * @param proof proof for the given claimer and amount
    * @returns txHash string
    */
-  public claimCFGRewards(claimerAccountID: string, amount: string, proof: Uint8Array[]): Promise<string> {
+  public async claimCFGRewards(claimerAccountID: string, amount: string, proof: Uint8Array[]): Promise<string> {
+    const { web3FromAddress } = await import('@polkadot/extension-dapp')
+
+    const address = accountIdToCentChainAddr(claimerAccountID)
+
+    const injector = await web3FromAddress(address)
+
     // eslint-disable-next-line no-async-promise-executor
     return new Promise(async (resolve, reject) => {
       const api = await this.api()
       const extrinsic = api.tx.radClaims.claim(claimerAccountID, amount, proof)
       await extrinsic
-        .send(({ status, dispatchError }) => {
+        .signAndSend(address, { signer: injector.signer }, ({ status, dispatchError }) => {
           // status would still be set, but in the case of error we can shortcut
           // to just check it (so an error would indicate InBlock or Finalized)
           if (dispatchError) {


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

<!-- Describe the goal of this pull request and if possible, insight on the implementation choices. -->

This pull request refactors the `claimCFGRewards` function to use `signAndSend` instead of just `send`. This will require the user to sign the transaction.

### Approvals

<!-- Depending on the nature of the pull request, remove the roles that are not necessary for this review. Intricate technical changes may require two dev approvals. Reviewers should check the corresponding box after they approve. -->

- [ ] Dev
- [ ] Product

### Impact

This pull request impacts CFG reward claiming.
