### PR TITLE
Centrifuge App: Pool detail liquidity tab

### DIFF
--- a/centrifuge-js/src/modules/pools.ts
+++ b/centrifuge-js/src/modules/pools.ts
@@ -196,6 +196,8 @@ export type Tranche = {
   outstandingInvestOrders: Balance
   outstandingRedeemOrders: Balance
   lastUpdatedInterest: string
+  investFulfillment?: Balance
+  redeemFulfillment?: Balance
 }
 
 export type TrancheWithTokenPrice = Tranche & {
@@ -958,6 +960,8 @@ export function getPoolsModule(inst: CentrifugeBase) {
                       lastUpdatedInterest: new Date(tranche.lastUpdatedInterest * 1000).toISOString(),
                       totalIssuance: new Balance(tokenIssuanceValues[index].toString()),
                       tokenPrice: new Price(lastEpoch[index]?.tokenPrice.toString() ?? '0'),
+                      investFulfillment: new Balance(hexToBN(lastEpoch[index]?.investFulfillment ?? '0')),
+                      redeemFulfillment: new Balance(hexToBN(lastEpoch[index]?.redeemFulfillment ?? '0')),
                     }
                   }),
                   reserve: {
@@ -993,7 +997,10 @@ export function getPoolsModule(inst: CentrifugeBase) {
 
     const $query = inst.getOptionalSubqueryObservable<{ dailyPoolStates: { nodes: SubqueryDailyPoolState[] } }>(
       `query($poolId: String!) {
-        dailyPoolStates(filter: {id:{startsWith: $poolId}}) {
+        dailyPoolStates(
+          filter: { 
+            id: { startsWith: $poolId },
+          }) {
           nodes {
             timestamp
             poolState {

--- a/centrifuge-js/src/modules/pools.ts
+++ b/centrifuge-js/src/modules/pools.ts
@@ -196,8 +196,6 @@ export type Tranche = {
   outstandingInvestOrders: Balance
   outstandingRedeemOrders: Balance
   lastUpdatedInterest: string
-  investFulfillment?: Balance
-  redeemFulfillment?: Balance
 }
 
 export type TrancheWithTokenPrice = Tranche & {
@@ -303,6 +301,7 @@ export type TrancheInput = {
 export type DailyPoolState = {
   poolState: {
     netAssetValue: Balance
+    totalReserve: Balance
   }
   poolValue: Balance
   currency: string
@@ -960,8 +959,6 @@ export function getPoolsModule(inst: CentrifugeBase) {
                       lastUpdatedInterest: new Date(tranche.lastUpdatedInterest * 1000).toISOString(),
                       totalIssuance: new Balance(tokenIssuanceValues[index].toString()),
                       tokenPrice: new Price(lastEpoch[index]?.tokenPrice.toString() ?? '0'),
-                      investFulfillment: new Balance(hexToBN(lastEpoch[index]?.investFulfillment ?? '0')),
-                      redeemFulfillment: new Balance(hexToBN(lastEpoch[index]?.redeemFulfillment ?? '0')),
                     }
                   }),
                   reserve: {
@@ -1026,6 +1023,7 @@ export function getPoolsModule(inst: CentrifugeBase) {
                 const poolState = {
                   ...state.poolState,
                   netAssetValue: new Balance(state.poolState.netAssetValue),
+                  totalReserve: new Balance(state.poolState.totalReserve),
                 }
                 const poolValue = new Balance(
                   new Balance(state?.poolState.netAssetValue || '0').add(

--- a/nft-studio/src/components/Charts/CustomChartElements.tsx
+++ b/nft-studio/src/components/Charts/CustomChartElements.tsx
@@ -1,4 +1,5 @@
 import { Box, Shelf, Stack, Text } from '@centrifuge/fabric'
+import * as React from 'react'
 import { AreaProps, TooltipProps } from 'recharts'
 import { useTheme } from 'styled-components'
 import { formatDate } from '../../utils/date'

--- a/nft-studio/src/components/Charts/CustomChartElements.tsx
+++ b/nft-studio/src/components/Charts/CustomChartElements.tsx
@@ -12,6 +12,7 @@ type CustomizedXAxisTickProps = {
   Pick<AreaProps, 'y'>
 
 export const CustomizedXAxisTick: React.VFC<CustomizedXAxisTickProps> = ({ payload, x, y, variant }) => {
+  const theme = useTheme()
   let tick
   if (variant === 'months') {
     const formatter = new Intl.DateTimeFormat('en', { month: 'short' })
@@ -23,8 +24,16 @@ export const CustomizedXAxisTick: React.VFC<CustomizedXAxisTickProps> = ({ paylo
   }
 
   return (
-    <g transform={`translate(${x},${y})`} style={{ fontSize: '10px', fontFamily: 'Inter' }}>
-      <text x={0} y={0} dy={16} fontSize="10px" textAnchor="center">
+    <g transform={`translate(${x},${y})`}>
+      <text
+        x={0}
+        y={0}
+        dy={16}
+        fontSize="10px"
+        fill={theme.colors.textSecondary}
+        fontFamily="Inter"
+        textAnchor="center"
+      >
         {tick}
       </text>
     </g>

--- a/nft-studio/src/components/Charts/CustomChartElements.tsx
+++ b/nft-studio/src/components/Charts/CustomChartElements.tsx
@@ -1,0 +1,72 @@
+import { Box, Shelf, Stack, Text } from '@centrifuge/fabric'
+import { AreaProps, TooltipProps } from 'recharts'
+import { useTheme } from 'styled-components'
+import { formatDate } from '../../utils/date'
+import { formatBalance, formatPercentage } from '../../utils/formatting'
+
+type CustomizedXAxisTickProps = {
+  payload?: { value: Date }
+  variant: 'months' | 'days'
+} & Pick<AreaProps, 'x'> &
+  Pick<AreaProps, 'y'>
+
+export const CustomizedXAxisTick: React.VFC<CustomizedXAxisTickProps> = ({ payload, x, y, variant }) => {
+  let tick
+  if (variant === 'months') {
+    const formatter = new Intl.DateTimeFormat('en', { month: 'short' })
+    // show month tick only on the first of every month
+    tick = payload?.value && new Date(payload.value).getDate() === 1 ? formatter.format(payload?.value) : null
+  } else {
+    const formatter = new Intl.DateTimeFormat('en', { day: 'numeric', month: 'short' })
+    tick = formatter.format(payload?.value)
+  }
+
+  return (
+    <g transform={`translate(${x},${y})`} style={{ fontSize: '10px', fontFamily: 'Inter' }}>
+      <text x={0} y={0} dy={16} fontSize="10px" textAnchor="center">
+        {tick}
+      </text>
+    </g>
+  )
+}
+
+type CustomizedTooltipProps = TooltipProps<any, any> & { currency: string }
+
+export const CustomizedTooltip: React.VFC<CustomizedTooltipProps> = ({ payload, currency }) => {
+  const theme = useTheme()
+  if (payload && payload?.length > 0) {
+    return (
+      <Stack
+        bg="backgroundPage"
+        p="1"
+        style={{
+          boxShadow: `1px 3px 6px ${theme.colors.borderSecondary}`,
+        }}
+        minWidth="180px"
+        gap="4px"
+      >
+        <Text variant="label2" fontWeight="500">
+          {formatDate(payload[0].payload.day)}
+        </Text>
+        {payload.map((item) => {
+          return (
+            <Shelf key={item.dataKey} gap="4px" justifyContent="space-between">
+              <Shelf gap="4px" alignItems="center">
+                <Box width="11px" height="11px" borderRadius="100%" backgroundColor={item.color} />
+                <Text variant="label2">{item.name}</Text>
+              </Shelf>
+              <Text alignSelf="flex-end" textAlign="right" variant="label2">
+                {typeof item.value !== 'number'
+                  ? formatBalance(item.value[1] - item.value[0], currency)
+                  : item.unit === 'percent'
+                  ? formatPercentage(item.value)
+                  : formatBalance(item.value, currency)}
+              </Text>
+            </Shelf>
+          )
+        })}
+      </Stack>
+    )
+  }
+  return null
+}

--- a/nft-studio/src/components/Charts/PoolAssetReserveChart.tsx
+++ b/nft-studio/src/components/Charts/PoolAssetReserveChart.tsx
@@ -1,0 +1,185 @@
+import { Box, Grid, Shelf, Stack, Text } from '@centrifuge/fabric'
+import React from 'react'
+import { useParams } from 'react-router'
+import {
+  Area,
+  AreaProps,
+  CartesianGrid,
+  ComposedChart,
+  Line,
+  ResponsiveContainer,
+  Tooltip,
+  TooltipProps,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import { useTheme } from 'styled-components'
+import { formatDate } from '../../utils/date'
+import { formatBalance, formatBalanceAbbreviated } from '../../utils/formatting'
+import { useDailyPoolStates, usePool } from '../../utils/usePools'
+import { Tooltips } from '../Tooltips'
+
+type ChartData = {
+  day: Date
+  poolValue: number
+  assetValue: number
+  reserve: [number, number]
+}
+
+export const PoolAssetReserveChart: React.VFC = () => {
+  const theme = useTheme()
+  const { pid: poolId } = useParams<{ pid: string }>()
+  const poolStates = useDailyPoolStates(poolId)
+  const pool = usePool(poolId)
+
+  const data: ChartData[] =
+    poolStates?.map((day) => {
+      const assetValue = day.poolState.netAssetValue.toDecimal().toNumber()
+      const poolValue = day.poolValue.toDecimal().toNumber()
+      return { day: new Date(day.timestamp), poolValue, assetValue, reserve: [assetValue, poolValue] }
+    }) || []
+
+  const todayPoolValue = pool?.value.toDecimal().toNumber() || 0
+  const todayAssetValue = pool?.nav.latest.toDecimal().toNumber() || 0
+  const today: ChartData = {
+    day: new Date(),
+    poolValue: todayPoolValue,
+    assetValue: todayAssetValue,
+    reserve: [todayAssetValue, todayPoolValue],
+  }
+
+  return (
+    <Stack>
+      <Legend data={today} currency={pool?.currency || ''} />
+      <Shelf gap="4" width="100%" color="textSecondary">
+        {[...data, today]?.length ? (
+          <ResponsiveContainer width="100%" height="100%" minHeight="200px">
+            <ComposedChart data={[...data, today]} margin={{ left: -30 }}>
+              <XAxis
+                dataKey="day"
+                tick={<CustomizedXAxisTick variant={[...data, today].length > 30 ? 'months' : 'days'} />}
+                tickLine={false}
+                interval={0}
+              />
+              <YAxis
+                tickLine={false}
+                style={{ fontSize: '10px', fontFamily: "'Inter'" }}
+                tickFormatter={(tick: number) => formatBalanceAbbreviated(tick)}
+              />
+              <CartesianGrid stroke={theme.colors.borderSecondary} />
+              <Area
+                fill={theme.colors.backgroundSecondary}
+                dataKey="reserve"
+                stroke={theme.colors.backgroundSecondary}
+                fillOpacity={1}
+              />
+              <Tooltip content={<CustomizedTooltip currency={pool?.currency || ''} />} />
+              <Line dot={false} dataKey="assetValue" stroke={theme.colors.accentSecondary} />
+              <Line dot={false} dataKey="poolValue" stroke={theme.colors.accentPrimary} />
+            </ComposedChart>
+          </ResponsiveContainer>
+        ) : (
+          <Text variant="label1">No data yet</Text>
+        )}
+      </Shelf>
+    </Stack>
+  )
+}
+
+const CustomizedTooltip: React.VFC<TooltipProps<any, any> & { currency: string }> = ({ payload, currency }) => {
+  const theme = useTheme()
+  if (payload && payload?.length > 0) {
+    const [reservePayload, assetPayload, poolPayload] = payload
+    return (
+      <Stack
+        bg="backgroundPage"
+        p="1"
+        style={{
+          boxShadow: `1px 3px 6px ${theme.colors.borderSecondary}`,
+        }}
+        minWidth="180px"
+        gap="4px"
+      >
+        <Text variant="label2" fontWeight="500">
+          {formatDate(payload[0].payload.day)}
+        </Text>
+        {[poolPayload, assetPayload, reservePayload].map((item) => {
+          return (
+            <Shelf key={item.dataKey} gap="4px" justifyContent="space-between">
+              <Shelf gap="4px" alignItems="center">
+                <Box width="11px" height="11px" borderRadius="100%" backgroundColor={item.color} />
+                <Text variant="label2">{toSentenceCase(item.name)}</Text>
+              </Shelf>
+              <Text alignSelf="flex-end" textAlign="right" variant="label2">
+                {formatBalance(item.name === 'reserve' ? item.value[1] - item.value[0] : item.value, currency)}
+              </Text>
+            </Shelf>
+          )
+        })}
+      </Stack>
+    )
+  }
+  return null
+}
+
+const Legend: React.VFC<{
+  currency: string
+  data: ChartData
+}> = ({ data, currency }) => {
+  const theme = useTheme()
+
+  return (
+    <Shelf bg="white" width="100%" gap="2">
+      <Grid pl="4" pb="4" columns={6} gap="3" width="100%">
+        <Stack borderLeftWidth="3px" pl="4px" borderLeftStyle="solid" borderLeftColor={theme.colors.accentPrimary}>
+          <Tooltips variant="secondary" type="poolValue" />
+          <Text variant="body2">{formatBalance(data.poolValue, currency)}</Text>
+        </Stack>
+        <Stack borderLeftWidth="3px" pl="4px" borderLeftStyle="solid" borderLeftColor={theme.colors.accentSecondary}>
+          <Tooltips variant="secondary" type="assetValue" />
+          <Text variant="body2">{formatBalance(data.assetValue, currency)}</Text>
+        </Stack>
+        <Stack borderLeftWidth="3px" pl="4px" borderLeftStyle="solid" borderLeftColor={theme.colors.borderSecondary}>
+          <Tooltips variant="secondary" type="reserve" />
+          <Text variant="body2">{formatBalance(data.reserve[1] - data.reserve[0], currency)}</Text>
+        </Stack>
+      </Grid>
+    </Shelf>
+  )
+}
+
+type CustomizedXAxisTickProps = {
+  payload?: { value: Date }
+  variant: 'months' | 'days'
+} & Pick<AreaProps, 'x'> &
+  Pick<AreaProps, 'y'>
+
+const CustomizedXAxisTick: React.VFC<CustomizedXAxisTickProps> = ({ payload, x, y, variant }) => {
+  let tick
+  if (variant === 'months') {
+    const formatter = new Intl.DateTimeFormat('en', { month: 'short' })
+    // show month tick only on the first of every month
+    tick = payload?.value && new Date(payload.value).getDate() === 1 ? formatter.format(payload?.value) : null
+  } else {
+    const formatter = new Intl.DateTimeFormat('en', { day: 'numeric', month: 'short' })
+    tick = formatter.format(payload?.value)
+  }
+
+  return (
+    <g transform={`translate(${x},${y})`} style={{ fontSize: '10px', fontFamily: 'Inter' }}>
+      <text x={0} y={0} dy={16} fontSize="10px" textAnchor="center">
+        {tick}
+      </text>
+    </g>
+  )
+}
+
+const toSentenceCase = (str: string) => {
+  return str
+    .split(/(?=[A-Z])/)
+    .map((word, index) => {
+      if (index === 0) return word.charAt(0).toUpperCase() + word.slice(1)
+      return word.charAt(0).toLowerCase() + word.slice(1)
+    })
+    .join(' ')
+}

--- a/nft-studio/src/components/Charts/ReserveCashDragChart.tsx
+++ b/nft-studio/src/components/Charts/ReserveCashDragChart.tsx
@@ -24,12 +24,13 @@ export const ReserveCashDragChart: React.VFC = () => {
     poolStates?.map((day) => {
       const assetValue = day.poolState.netAssetValue.toDecimal().toNumber()
       const reserve = day.poolState.totalReserve.toDecimal().toNumber()
-      return { day: new Date(day.timestamp), cashDrag: reserve / (reserve + assetValue) || 0, reserve }
+      const cashDrag = (reserve / (reserve + assetValue)) * 100
+      return { day: new Date(day.timestamp), cashDrag: cashDrag || 0, reserve }
     }) || []
 
   const todayAssetValue = pool?.nav.latest.toDecimal().toNumber() || 0
   const todayReserve = pool?.reserve.total.toDecimal().toNumber() || 0
-  const cashDrag = todayReserve / (todayAssetValue + todayReserve)
+  const cashDrag = (todayReserve / (todayAssetValue + todayReserve)) * 100
   const today: ChartData = {
     day: new Date(),
     cashDrag: cashDrag || 0,

--- a/nft-studio/src/components/Charts/ReserveCashDragChart.tsx
+++ b/nft-studio/src/components/Charts/ReserveCashDragChart.tsx
@@ -1,22 +1,12 @@
-import { Box, Grid, Shelf, Stack, Text } from '@centrifuge/fabric'
+import { Grid, Shelf, Stack, Text } from '@centrifuge/fabric'
 import React from 'react'
 import { useParams } from 'react-router'
-import {
-  AreaProps,
-  CartesianGrid,
-  ComposedChart,
-  Line,
-  ResponsiveContainer,
-  Tooltip,
-  TooltipProps,
-  XAxis,
-  YAxis,
-} from 'recharts'
+import { CartesianGrid, ComposedChart, Line, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
 import { useTheme } from 'styled-components'
-import { formatDate } from '../../utils/date'
 import { formatBalance, formatBalanceAbbreviated, formatPercentage } from '../../utils/formatting'
 import { useDailyPoolStates, usePool } from '../../utils/usePools'
 import { Tooltips } from '../Tooltips'
+import { CustomizedTooltip, CustomizedXAxisTick } from './CustomChartElements'
 
 type ChartData = {
   day: Date
@@ -49,7 +39,7 @@ export const ReserveCashDragChart: React.VFC = () => {
 
   return (
     <Stack>
-      <Legend data={today} currency={pool?.currency || ''} />
+      <CustomLegend data={today} currency={pool?.currency || ''} />
       <Shelf gap="4" width="100%" color="textSecondary">
         {[...data, today]?.length ? (
           <ResponsiveContainer width="100%" height="100%" minHeight="200px">
@@ -76,8 +66,15 @@ export const ReserveCashDragChart: React.VFC = () => {
               />
               <CartesianGrid stroke={theme.colors.borderSecondary} />
               <Tooltip content={<CustomizedTooltip currency={pool?.currency || ''} />} />
-              <Line dot={false} dataKey="cashDrag" yAxisId="right" stroke={theme.colors.accentSecondary} />
-              <Line dot={false} dataKey="reserve" yAxisId="left" stroke={theme.colors.accentPrimary} />
+              <Line dot={false} dataKey="reserve" yAxisId="left" stroke={theme.colors.accentPrimary} name="Reserve" />
+              <Line
+                dot={false}
+                dataKey="cashDrag"
+                yAxisId="right"
+                stroke={theme.colors.accentSecondary}
+                unit="percent"
+                name="Cash drag"
+              />
             </ComposedChart>
           </ResponsiveContainer>
         ) : (
@@ -88,43 +85,7 @@ export const ReserveCashDragChart: React.VFC = () => {
   )
 }
 
-const CustomizedTooltip: React.VFC<TooltipProps<any, any> & { currency: string }> = ({ payload, currency }) => {
-  const theme = useTheme()
-  if (payload && payload?.length > 0) {
-    const [reservePayload, cashDragPayload] = payload
-    return (
-      <Stack
-        bg="backgroundPage"
-        p="1"
-        style={{
-          boxShadow: `1px 3px 6px ${theme.colors.borderSecondary}`,
-        }}
-        minWidth="180px"
-        gap="4px"
-      >
-        <Text variant="label2" fontWeight="500">
-          {formatDate(payload[0].payload.day)}
-        </Text>
-        {[cashDragPayload, reservePayload].map((item) => {
-          return (
-            <Shelf key={item.dataKey} gap="4px" justifyContent="space-between">
-              <Shelf gap="4px" alignItems="center">
-                <Box width="11px" height="11px" borderRadius="100%" backgroundColor={item.color} />
-                <Text variant="label2">{toSentenceCase(item.name)}</Text>
-              </Shelf>
-              <Text alignSelf="flex-end" textAlign="right" variant="label2">
-                {item.name === 'reserve' ? formatBalance(item.value, currency) : formatPercentage(item.value)}
-              </Text>
-            </Shelf>
-          )
-        })}
-      </Stack>
-    )
-  }
-  return null
-}
-
-const Legend: React.VFC<{
+const CustomLegend: React.VFC<{
   currency: string
   data: ChartData
 }> = ({ data, currency }) => {
@@ -144,40 +105,4 @@ const Legend: React.VFC<{
       </Grid>
     </Shelf>
   )
-}
-
-type CustomizedXAxisTickProps = {
-  payload?: { value: Date }
-  variant: 'months' | 'days'
-} & Pick<AreaProps, 'x'> &
-  Pick<AreaProps, 'y'>
-
-const CustomizedXAxisTick: React.VFC<CustomizedXAxisTickProps> = ({ payload, x, y, variant }) => {
-  let tick
-  if (variant === 'months') {
-    const formatter = new Intl.DateTimeFormat('en', { month: 'short' })
-    // show month tick only on the first of every month
-    tick = payload?.value && new Date(payload.value).getDate() === 1 ? formatter.format(payload?.value) : null
-  } else {
-    const formatter = new Intl.DateTimeFormat('en', { day: 'numeric', month: 'short' })
-    tick = formatter.format(payload?.value)
-  }
-
-  return (
-    <g transform={`translate(${x},${y})`} style={{ fontSize: '10px', fontFamily: 'Inter' }}>
-      <text x={0} y={0} dy={16} fontSize="10px" textAnchor="center">
-        {tick}
-      </text>
-    </g>
-  )
-}
-
-const toSentenceCase = (str: string) => {
-  return str
-    .split(/(?=[A-Z])/)
-    .map((word, index) => {
-      if (index === 0) return word.charAt(0).toUpperCase() + word.slice(1)
-      return word.charAt(0).toLowerCase() + word.slice(1)
-    })
-    .join(' ')
 }

--- a/nft-studio/src/components/Charts/ReserveCashDragChart.tsx
+++ b/nft-studio/src/components/Charts/ReserveCashDragChart.tsx
@@ -31,9 +31,10 @@ export const ReserveCashDragChart: React.VFC = () => {
   const todayPoolValue = pool?.value.toDecimal().toNumber() || 0
   const todayAssetValue = pool?.nav.latest.toDecimal().toNumber() || 0
   const reserve = todayPoolValue - todayAssetValue
+  const cashDrag = todayAssetValue / reserve
   const today: ChartData = {
     day: new Date(),
-    cashDrag: todayAssetValue / reserve,
+    cashDrag: cashDrag || 0,
     reserve,
   }
 

--- a/nft-studio/src/components/Charts/ReserveCashDragChart.tsx
+++ b/nft-studio/src/components/Charts/ReserveCashDragChart.tsx
@@ -1,0 +1,183 @@
+import { Box, Grid, Shelf, Stack, Text } from '@centrifuge/fabric'
+import React from 'react'
+import { useParams } from 'react-router'
+import {
+  AreaProps,
+  CartesianGrid,
+  ComposedChart,
+  Line,
+  ResponsiveContainer,
+  Tooltip,
+  TooltipProps,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import { useTheme } from 'styled-components'
+import { formatDate } from '../../utils/date'
+import { formatBalance, formatBalanceAbbreviated, formatPercentage } from '../../utils/formatting'
+import { useDailyPoolStates, usePool } from '../../utils/usePools'
+import { Tooltips } from '../Tooltips'
+
+type ChartData = {
+  day: Date
+  cashDrag: number
+  reserve: number
+}
+
+export const ReserveCashDragChart: React.VFC = () => {
+  const theme = useTheme()
+  const { pid: poolId } = useParams<{ pid: string }>()
+  const poolStates = useDailyPoolStates(poolId)
+  const pool = usePool(poolId)
+
+  const data: ChartData[] =
+    poolStates?.map((day) => {
+      const assetValue = day.poolState.netAssetValue.toDecimal().toNumber()
+      const poolValue = day.poolValue.toDecimal().toNumber()
+      const reserve = poolValue - assetValue
+      return { day: new Date(day.timestamp), cashDrag: assetValue / reserve || 0, reserve }
+    }) || []
+
+  const todayPoolValue = pool?.value.toDecimal().toNumber() || 0
+  const todayAssetValue = pool?.nav.latest.toDecimal().toNumber() || 0
+  const reserve = todayPoolValue - todayAssetValue
+  const today: ChartData = {
+    day: new Date(),
+    cashDrag: todayAssetValue / reserve,
+    reserve,
+  }
+
+  return (
+    <Stack>
+      <Legend data={today} currency={pool?.currency || ''} />
+      <Shelf gap="4" width="100%" color="textSecondary">
+        {[...data, today]?.length ? (
+          <ResponsiveContainer width="100%" height="100%" minHeight="200px">
+            <ComposedChart data={[...data, today]} margin={{ left: -30 }}>
+              <XAxis
+                dataKey="day"
+                tick={<CustomizedXAxisTick variant={[...data, today].length > 30 ? 'months' : 'days'} />}
+                tickLine={false}
+                interval={0}
+              />
+              <YAxis
+                yAxisId="left"
+                tickLine={false}
+                style={{ fontSize: '10px', fontFamily: "'Inter'" }}
+                tickFormatter={(tick: number) => formatBalanceAbbreviated(tick)}
+              />
+              <YAxis
+                yAxisId="right"
+                orientation="right"
+                style={{ fontSize: '10px', fontFamily: "'Inter'" }}
+                tickMargin={5}
+                tickLine={false}
+                tickFormatter={(tick: number) => `${tick}%`}
+              />
+              <CartesianGrid stroke={theme.colors.borderSecondary} />
+              <Tooltip content={<CustomizedTooltip currency={pool?.currency || ''} />} />
+              <Line dot={false} dataKey="cashDrag" yAxisId="right" stroke={theme.colors.accentSecondary} />
+              <Line dot={false} dataKey="reserve" yAxisId="left" stroke={theme.colors.accentPrimary} />
+            </ComposedChart>
+          </ResponsiveContainer>
+        ) : (
+          <Text variant="label1">No data yet</Text>
+        )}
+      </Shelf>
+    </Stack>
+  )
+}
+
+const CustomizedTooltip: React.VFC<TooltipProps<any, any> & { currency: string }> = ({ payload, currency }) => {
+  const theme = useTheme()
+  if (payload && payload?.length > 0) {
+    const [reservePayload, cashDragPayload] = payload
+    return (
+      <Stack
+        bg="backgroundPage"
+        p="1"
+        style={{
+          boxShadow: `1px 3px 6px ${theme.colors.borderSecondary}`,
+        }}
+        minWidth="180px"
+        gap="4px"
+      >
+        <Text variant="label2" fontWeight="500">
+          {formatDate(payload[0].payload.day)}
+        </Text>
+        {[cashDragPayload, reservePayload].map((item) => {
+          return (
+            <Shelf key={item.dataKey} gap="4px" justifyContent="space-between">
+              <Shelf gap="4px" alignItems="center">
+                <Box width="11px" height="11px" borderRadius="100%" backgroundColor={item.color} />
+                <Text variant="label2">{toSentenceCase(item.name)}</Text>
+              </Shelf>
+              <Text alignSelf="flex-end" textAlign="right" variant="label2">
+                {item.name === 'reserve' ? formatBalance(item.value, currency) : formatPercentage(item.value)}
+              </Text>
+            </Shelf>
+          )
+        })}
+      </Stack>
+    )
+  }
+  return null
+}
+
+const Legend: React.VFC<{
+  currency: string
+  data: ChartData
+}> = ({ data, currency }) => {
+  const theme = useTheme()
+
+  return (
+    <Shelf bg="white" width="100%" gap="2">
+      <Grid pl="4" pb="4" columns={6} gap="3" width="100%">
+        <Stack borderLeftWidth="3px" pl="4px" borderLeftStyle="solid" borderLeftColor={theme.colors.accentPrimary}>
+          <Tooltips variant="secondary" type="reserve" />
+          <Text variant="body2">{formatBalance(data.reserve, currency)}</Text>
+        </Stack>
+        <Stack borderLeftWidth="3px" pl="4px" borderLeftStyle="solid" borderLeftColor={theme.colors.accentSecondary}>
+          <Tooltips variant="secondary" type="cashDrag" />
+          <Text variant="body2">{formatPercentage(data.cashDrag)}</Text>
+        </Stack>
+      </Grid>
+    </Shelf>
+  )
+}
+
+type CustomizedXAxisTickProps = {
+  payload?: { value: Date }
+  variant: 'months' | 'days'
+} & Pick<AreaProps, 'x'> &
+  Pick<AreaProps, 'y'>
+
+const CustomizedXAxisTick: React.VFC<CustomizedXAxisTickProps> = ({ payload, x, y, variant }) => {
+  let tick
+  if (variant === 'months') {
+    const formatter = new Intl.DateTimeFormat('en', { month: 'short' })
+    // show month tick only on the first of every month
+    tick = payload?.value && new Date(payload.value).getDate() === 1 ? formatter.format(payload?.value) : null
+  } else {
+    const formatter = new Intl.DateTimeFormat('en', { day: 'numeric', month: 'short' })
+    tick = formatter.format(payload?.value)
+  }
+
+  return (
+    <g transform={`translate(${x},${y})`} style={{ fontSize: '10px', fontFamily: 'Inter' }}>
+      <text x={0} y={0} dy={16} fontSize="10px" textAnchor="center">
+        {tick}
+      </text>
+    </g>
+  )
+}
+
+const toSentenceCase = (str: string) => {
+  return str
+    .split(/(?=[A-Z])/)
+    .map((word, index) => {
+      if (index === 0) return word.charAt(0).toUpperCase() + word.slice(1)
+      return word.charAt(0).toLowerCase() + word.slice(1)
+    })
+    .join(' ')
+}

--- a/nft-studio/src/components/Charts/ReserveCashDragChart.tsx
+++ b/nft-studio/src/components/Charts/ReserveCashDragChart.tsx
@@ -23,19 +23,17 @@ export const ReserveCashDragChart: React.VFC = () => {
   const data: ChartData[] =
     poolStates?.map((day) => {
       const assetValue = day.poolState.netAssetValue.toDecimal().toNumber()
-      const poolValue = day.poolValue.toDecimal().toNumber()
-      const reserve = poolValue - assetValue
-      return { day: new Date(day.timestamp), cashDrag: assetValue / reserve || 0, reserve }
+      const reserve = day.poolState.totalReserve.toDecimal().toNumber()
+      return { day: new Date(day.timestamp), cashDrag: reserve / (reserve + assetValue) || 0, reserve }
     }) || []
 
-  const todayPoolValue = pool?.value.toDecimal().toNumber() || 0
   const todayAssetValue = pool?.nav.latest.toDecimal().toNumber() || 0
-  const reserve = todayPoolValue - todayAssetValue
-  const cashDrag = todayAssetValue / reserve
+  const todayReserve = pool?.reserve.total.toDecimal().toNumber() || 0
+  const cashDrag = todayReserve / (todayAssetValue + todayReserve)
   const today: ChartData = {
     day: new Date(),
     cashDrag: cashDrag || 0,
-    reserve,
+    reserve: todayReserve,
   }
 
   return (

--- a/nft-studio/src/components/Charts/RiskGroupSharesPieChart.tsx
+++ b/nft-studio/src/components/Charts/RiskGroupSharesPieChart.tsx
@@ -8,7 +8,7 @@ type PieChartProps = {
 
 const RADIAN = Math.PI / 180
 
-export const PieChart: React.VFC<PieChartProps> = ({ data }) => {
+export const RiskGroupSharesPieChart: React.VFC<PieChartProps> = ({ data }) => {
   const theme = useTheme()
   const renderCustomizedLabel = ({ cx, cy, midAngle, outerRadius, percent, payload }: PieLabelRenderProps) => {
     const outerLabelRadius = (outerRadius as number) * 0.5 + 60

--- a/nft-studio/src/components/DataTable.tsx
+++ b/nft-studio/src/components/DataTable.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 
 type GroupedProps = {
   groupIndex?: number
-  lastIndex?: number
+  lastGroupIndex?: number
 }
 
 type Props<T> = {
@@ -44,7 +44,7 @@ export const DataTable = <T extends Record<string, any>>({
   rounded = true,
   summary,
   groupIndex,
-  lastIndex,
+  lastGroupIndex,
 }: Props<T>) => {
   const [orderBy, setOrderBy] = React.useState<Record<string, OrderBy>>(
     defaultSortKey ? { [defaultSortKey]: 'desc' } : {}
@@ -65,7 +65,7 @@ export const DataTable = <T extends Record<string, any>>({
 
   const showHeader = groupIndex === 0 || !groupIndex
   return (
-    <Stack as={rounded && !lastIndex ? Card : Stack}>
+    <Stack as={rounded && !lastGroupIndex ? Card : Stack}>
       <Shelf>
         {showHeader &&
           columns.map((col, i) => (
@@ -103,9 +103,9 @@ export const DataTable = <T extends Record<string, any>>({
         ))}
         {/* summary row is not included in sorting */}
         {summary && (
-          <Row rounded={rounded && groupIndex === lastIndex}>
+          <Row rounded={rounded && groupIndex === lastGroupIndex}>
             {columns.map((col, i) => (
-              <DataCol key={col.sortKey} style={{ flex: col.flex }} align={col?.align}>
+              <DataCol key={`${col.sortKey}-${i}`} style={{ flex: col.flex }} align={col?.align}>
                 {col.cell(summary, i)}
               </DataCol>
             ))}

--- a/nft-studio/src/components/DataTable.tsx
+++ b/nft-studio/src/components/DataTable.tsx
@@ -3,6 +3,11 @@ import css from '@styled-system/css'
 import * as React from 'react'
 import styled from 'styled-components'
 
+type GroupedProps = {
+  groupIndex?: number
+  lastIndex?: number
+}
+
 type Props<T> = {
   data: Array<T>
   columns: Column[]
@@ -11,7 +16,7 @@ type Props<T> = {
   defaultSortKey?: string
   rounded?: boolean
   summary?: T
-}
+} & GroupedProps
 
 export type OrderBy = 'asc' | 'desc'
 
@@ -38,6 +43,8 @@ export const DataTable = <T extends Record<string, any>>({
   defaultSortKey,
   rounded = true,
   summary,
+  groupIndex,
+  lastIndex,
 }: Props<T>) => {
   const [orderBy, setOrderBy] = React.useState<Record<string, OrderBy>>(
     defaultSortKey ? { [defaultSortKey]: 'desc' } : {}
@@ -56,25 +63,27 @@ export const DataTable = <T extends Record<string, any>>({
     [orderBy, data, currentSortKey]
   )
 
+  const showHeader = groupIndex === 0 || !groupIndex
   return (
-    <Stack as={rounded ? Card : Stack}>
+    <Stack as={rounded && !lastIndex ? Card : Stack}>
       <Shelf>
-        {columns.map((col, i) => (
-          <HeaderCol
-            key={`${col.header}-${i}`}
-            style={{ flex: col.flex }}
-            tabIndex={col?.sortKey ? 0 : undefined}
-            as={col?.sortKey ? 'button' : 'div'}
-            onClick={col?.sortKey ? () => updateSortOrder(col.sortKey) : () => undefined}
-            align={col?.align}
-          >
-            <Text variant="label2">
-              {col?.header && typeof col.header !== 'string' && col?.sortKey && React.isValidElement(col.header())
-                ? React.cloneElement(col.header(), { align: col?.align, orderBy: orderBy[col.sortKey] })
-                : col.header}
-            </Text>
-          </HeaderCol>
-        ))}
+        {showHeader &&
+          columns.map((col, i) => (
+            <HeaderCol
+              key={`${col.header}-${i}`}
+              style={{ flex: col.flex }}
+              tabIndex={col?.sortKey ? 0 : undefined}
+              as={col?.sortKey ? 'button' : 'div'}
+              onClick={col?.sortKey ? () => updateSortOrder(col.sortKey) : () => undefined}
+              align={col?.align}
+            >
+              <Text variant="label2">
+                {col?.header && typeof col.header !== 'string' && col?.sortKey && React.isValidElement(col.header())
+                  ? React.cloneElement(col.header(), { align: col?.align, orderBy: orderBy[col.sortKey] })
+                  : col.header}
+              </Text>
+            </HeaderCol>
+          ))}
       </Shelf>
       <Stack>
         {sortedData?.map((row, i) => (
@@ -94,7 +103,7 @@ export const DataTable = <T extends Record<string, any>>({
         ))}
         {/* summary row is not included in sorting */}
         {summary && (
-          <Row rounded={rounded}>
+          <Row rounded={rounded && groupIndex === lastIndex}>
             {columns.map((col, i) => (
               <DataCol key={col.sortKey} style={{ flex: col.flex }} align={col?.align}>
                 {col.cell(summary, i)}

--- a/nft-studio/src/components/DataTableGroup.tsx
+++ b/nft-studio/src/components/DataTableGroup.tsx
@@ -1,0 +1,17 @@
+import { Card, Stack } from '@centrifuge/fabric'
+import * as React from 'react'
+
+export const DataTableGroup: React.FC = ({ children }) => {
+  return (
+    <Stack as={Card} gap="3">
+      {React.Children.map(children, (child, index) => {
+        return React.isValidElement(child)
+          ? React.cloneElement(child, {
+              groupIndex: index,
+              lastIndex: React.Children.count(children) - 1,
+            })
+          : null
+      })}
+    </Stack>
+  )
+}

--- a/nft-studio/src/components/DataTableGroup.tsx
+++ b/nft-studio/src/components/DataTableGroup.tsx
@@ -8,7 +8,7 @@ export const DataTableGroup: React.FC = ({ children }) => {
         return React.isValidElement(child)
           ? React.cloneElement(child, {
               groupIndex: index,
-              lastIndex: React.Children.count(children) - 1,
+              lastGroupIndex: React.Children.count(children) - 1,
             })
           : null
       })}

--- a/nft-studio/src/components/EpochList.tsx
+++ b/nft-studio/src/components/EpochList.tsx
@@ -1,0 +1,41 @@
+import { Stack, Text } from '@centrifuge/fabric'
+import * as React from 'react'
+import { useParams } from 'react-router'
+import { formatBalance } from '../utils/formatting'
+import { usePool } from '../utils/usePools'
+import { Column, DataTable, SortableTableHeader } from './DataTable'
+
+type Props = {
+  investments: any[]
+  redmetions: any[]
+}
+
+export const EpochList: React.FC<Props> = ({ investments, redmetions }) => {
+  const columns: Column[] = [
+    {
+      align: 'left',
+      header: () => <SortableTableHeader label="Order" />,
+      cell: (row: any) => <Text>{row.order}</Text>,
+      sortKey: 'order',
+      flex: '1',
+    },
+    {
+      header: 'Locked',
+      cell: (row: any) => <LockedRow row={row} />,
+      flex: '1',
+    },
+  ]
+
+  return (
+    <Stack gap="3">
+      <DataTable data={investments} columns={columns} />
+      <DataTable data={redmetions} columns={columns} />
+    </Stack>
+  )
+}
+
+const LockedRow: React.VFC<{ row: any }> = ({ row }) => {
+  const { pid: poolId } = useParams<{ pid: string }>()
+  const pool = usePool(poolId)
+  return <Text variant="body2">{formatBalance(row.locked, pool?.currency)}</Text>
+}

--- a/nft-studio/src/components/EpochList.tsx
+++ b/nft-studio/src/components/EpochList.tsx
@@ -1,4 +1,4 @@
-import { Balance, DetailedPool } from '@centrifuge/centrifuge-js'
+import { DetailedPool } from '@centrifuge/centrifuge-js'
 import { Stack, Text } from '@centrifuge/fabric'
 import Decimal from 'decimal.js-light'
 import * as React from 'react'
@@ -13,21 +13,21 @@ type Props = {
   pool: DetailedPool
 }
 
-type TableData = {
-  order: string
-  locked: Decimal | undefined
+type TableDataRow = {
+  order: string | React.ReactElement
+  locked: Decimal | React.ReactElement
 }
 
 const columns: Column[] = [
   {
     align: 'left',
     header: 'Order',
-    cell: (row: TableData) => <Text>{row.order}</Text>,
+    cell: (row: TableDataRow) => <Text variant="body2">{row.order}</Text>,
     flex: '1',
   },
   {
     header: 'Locked',
-    cell: (row: TableData) => <LockedRow row={row} />,
+    cell: (row: TableDataRow) => <LockedRow row={row} />,
     flex: '1',
   },
 ]
@@ -35,38 +35,62 @@ const columns: Column[] = [
 export const EpochList: React.FC<Props> = ({ pool }) => {
   const { data: metadata } = usePoolMetadata(pool)
 
-  const investments: TableData[] = pool.tranches.map((token) => {
+  const investments: TableDataRow[] = pool.tranches.map((token) => {
     const trancheMeta = metadata?.tranches?.[token.seniority]
     return {
       order: `${trancheMeta?.symbol} investments`,
-      locked: token.investFulfillment?.toDecimal(),
+      locked: token.investFulfillment?.toDecimal() || new Decimal(0),
     }
   })
 
-  const redmetions: TableData[] = pool.tranches.map((token) => {
+  const redmetions: TableDataRow[] = pool.tranches.map((token) => {
     const trancheMeta = metadata?.tranches?.[token.seniority]
     return {
       order: `${trancheMeta?.symbol} redemptions`,
-      locked: token.redeemFulfillment?.toDecimal(),
+      locked: token.redeemFulfillment?.toDecimal() || new Decimal(0),
     }
   })
 
-  const summaryInvestments: TableData = {
-    order: 'Total investments',
-    locked: new Balance(0).toDecimal(),
+  const summaryInvestments: TableDataRow = {
+    order: (
+      <Text variant="body2" fontWeight={600}>
+        Total investments
+      </Text>
+    ),
+    locked: (
+      <Text variant="body2" fontWeight={600}>
+        {formatBalance(
+          investments.reduce((prev, curr) => prev.add(curr.locked as Decimal), new Decimal(0)),
+          pool.currency
+        )}
+      </Text>
+    ),
   }
 
-  const summaryRedemtions: TableData = {
-    order: 'Total investments',
-    locked: new Balance(0).toDecimal(),
+  const summaryRedemtions: TableDataRow = {
+    order: (
+      <Text variant="body2" fontWeight={600}>
+        Total redemptions
+      </Text>
+    ),
+    locked: (
+      <Text variant="body2" fontWeight={600}>
+        {formatBalance(
+          redmetions.reduce((prev, curr) => prev.add(curr.locked as Decimal), new Decimal(0)),
+          pool.currency
+        )}
+      </Text>
+    ),
   }
 
   return (
-    <Stack gap="3">
-      <DataTableGroup>
-        <DataTable data={investments} columns={columns} summary={summaryInvestments} />
-        <DataTable data={redmetions} columns={columns} summary={summaryRedemtions} />
-      </DataTableGroup>
+    <Stack gap="2">
+      <Stack gap="3">
+        <DataTableGroup>
+          <DataTable data={investments} columns={columns} summary={summaryInvestments} />
+          <DataTable data={redmetions} columns={columns} summary={summaryRedemtions} />
+        </DataTableGroup>
+      </Stack>
       <Text variant="body3" color="textSecondary">
         An epoch is a period of locking investments and redemptions.{' '}
         <AnchorTextLink href="https://docs.centrifuge.io/learn/epoch/">Learn more</AnchorTextLink>
@@ -75,8 +99,12 @@ export const EpochList: React.FC<Props> = ({ pool }) => {
   )
 }
 
-const LockedRow: React.VFC<{ row: any }> = ({ row }) => {
+const LockedRow: React.VFC<{ row: TableDataRow }> = ({ row }) => {
   const { pid: poolId } = useParams<{ pid: string }>()
   const pool = usePool(poolId)
-  return <Text variant="body2">{row.locked ? formatBalance(row.locked, pool?.currency) : ''}</Text>
+  return (
+    <Text variant="body2">
+      {React.isValidElement(row.locked) ? row.locked : formatBalance(row.locked, pool?.currency)}
+    </Text>
+  )
 }

--- a/nft-studio/src/components/EpochList.tsx
+++ b/nft-studio/src/components/EpochList.tsx
@@ -1,35 +1,71 @@
+import { Balance, DetailedPool } from '@centrifuge/centrifuge-js'
 import { Stack, Text } from '@centrifuge/fabric'
+import Decimal from 'decimal.js-light'
 import * as React from 'react'
 import { useParams } from 'react-router'
 import { formatBalance } from '../utils/formatting'
-import { usePool } from '../utils/usePools'
-import { Column, DataTable, SortableTableHeader } from './DataTable'
+import { usePool, usePoolMetadata } from '../utils/usePools'
+import { Column, DataTable } from './DataTable'
+import { DataTableGroup } from './DataTableGroup'
 
 type Props = {
-  investments: any[]
-  redmetions: any[]
+  pool: DetailedPool
 }
 
-export const EpochList: React.FC<Props> = ({ investments, redmetions }) => {
-  const columns: Column[] = [
-    {
-      align: 'left',
-      header: () => <SortableTableHeader label="Order" />,
-      cell: (row: any) => <Text>{row.order}</Text>,
-      sortKey: 'order',
-      flex: '1',
-    },
-    {
-      header: 'Locked',
-      cell: (row: any) => <LockedRow row={row} />,
-      flex: '1',
-    },
-  ]
+type TableData = {
+  order: string
+  locked: Decimal | undefined
+}
+
+const columns: Column[] = [
+  {
+    align: 'left',
+    header: 'Order',
+    cell: (row: TableData) => <Text>{row.order}</Text>,
+    flex: '1',
+  },
+  {
+    header: 'Locked',
+    cell: (row: TableData) => <LockedRow row={row} />,
+    flex: '1',
+  },
+]
+
+export const EpochList: React.FC<Props> = ({ pool }) => {
+  const { data: metadata } = usePoolMetadata(pool)
+
+  const investments: TableData[] = pool.tranches.map((token) => {
+    const trancheMeta = metadata?.tranches?.[token.seniority]
+    return {
+      order: `${trancheMeta?.symbol} investments`,
+      locked: token.investFulfillment?.toDecimal(),
+    }
+  })
+
+  const redmetions: TableData[] = pool.tranches.map((token) => {
+    const trancheMeta = metadata?.tranches?.[token.seniority]
+    return {
+      order: `${trancheMeta?.symbol} redemptions`,
+      locked: token.redeemFulfillment?.toDecimal(),
+    }
+  })
+
+  const summaryInvestments: TableData = {
+    order: 'Total investments',
+    locked: new Balance(0).toDecimal(),
+  }
+
+  const summaryRedemtions: TableData = {
+    order: 'Total investments',
+    locked: new Balance(0).toDecimal(),
+  }
 
   return (
     <Stack gap="3">
-      <DataTable data={investments} columns={columns} />
-      <DataTable data={redmetions} columns={columns} />
+      <DataTableGroup>
+        <DataTable data={investments} columns={columns} summary={summaryInvestments} />
+        <DataTable data={redmetions} columns={columns} summary={summaryRedemtions} />
+      </DataTableGroup>
     </Stack>
   )
 }
@@ -37,5 +73,5 @@ export const EpochList: React.FC<Props> = ({ investments, redmetions }) => {
 const LockedRow: React.VFC<{ row: any }> = ({ row }) => {
   const { pid: poolId } = useParams<{ pid: string }>()
   const pool = usePool(poolId)
-  return <Text variant="body2">{formatBalance(row.locked, pool?.currency)}</Text>
+  return <Text variant="body2">{row.locked ? formatBalance(row.locked, pool?.currency) : ''}</Text>
 }

--- a/nft-studio/src/components/EpochList.tsx
+++ b/nft-studio/src/components/EpochList.tsx
@@ -7,6 +7,7 @@ import { formatBalance } from '../utils/formatting'
 import { usePool, usePoolMetadata } from '../utils/usePools'
 import { Column, DataTable } from './DataTable'
 import { DataTableGroup } from './DataTableGroup'
+import { AnchorTextLink } from './TextLink'
 
 type Props = {
   pool: DetailedPool
@@ -66,6 +67,10 @@ export const EpochList: React.FC<Props> = ({ pool }) => {
         <DataTable data={investments} columns={columns} summary={summaryInvestments} />
         <DataTable data={redmetions} columns={columns} summary={summaryRedemtions} />
       </DataTableGroup>
+      <Text variant="body3" color="textSecondary">
+        An epoch is a period of locking investments and redemptions.{' '}
+        <AnchorTextLink href="https://docs.centrifuge.io/learn/epoch/">Learn more</AnchorTextLink>
+      </Text>
     </Stack>
   )
 }

--- a/nft-studio/src/components/EpochList.tsx
+++ b/nft-studio/src/components/EpochList.tsx
@@ -39,7 +39,7 @@ export const EpochList: React.FC<Props> = ({ pool }) => {
     const trancheMeta = metadata?.tranches?.[token.seniority]
     return {
       order: `${trancheMeta?.symbol} investments`,
-      locked: token.investFulfillment?.toDecimal() || new Decimal(0),
+      locked: token.outstandingInvestOrders?.toDecimal() || new Decimal(0),
     }
   })
 
@@ -47,7 +47,7 @@ export const EpochList: React.FC<Props> = ({ pool }) => {
     const trancheMeta = metadata?.tranches?.[token.seniority]
     return {
       order: `${trancheMeta?.symbol} redemptions`,
-      locked: token.redeemFulfillment?.toDecimal() || new Decimal(0),
+      locked: token.outstandingRedeemOrders?.toDecimal() || new Decimal(0),
     }
   })
 

--- a/nft-studio/src/components/InvestRedeem.tsx
+++ b/nft-studio/src/components/InvestRedeem.tsx
@@ -19,6 +19,7 @@ import Decimal from 'decimal.js-light'
 import { Field, FieldProps, Form, FormikErrors, FormikProvider, useFormik } from 'formik'
 import * as React from 'react'
 import styled from 'styled-components'
+import { getEpochHoursRemaining } from '../utils/date'
 import { Dec } from '../utils/Decimal'
 import { formatBalance, getCurrencySymbol } from '../utils/formatting'
 import { useAddress } from '../utils/useAddress'
@@ -68,13 +69,6 @@ function validateNumberInput(value: number | string | Decimal, min: number | Dec
   if (Dec(value).lessThan(Dec(min))) {
     return 'Value too small'
   }
-}
-
-function getEpochHoursRemaining(pool: DetailedPool) {
-  const last = new Date(pool.epoch.lastClosed).getTime()
-  const min = pool.parameters.minEpochTime * 1000
-  const now = Date.now()
-  return Math.ceil(Math.max(0, last + min - now) / (1000 * 60 * 60))
 }
 
 const InvestRedeemInner: React.VFC<Props> = ({ poolId, trancheId }) => {

--- a/nft-studio/src/components/RiskGroupList.tsx
+++ b/nft-studio/src/components/RiskGroupList.tsx
@@ -7,8 +7,8 @@ import { Dec } from '../utils/Decimal'
 import { formatBalance } from '../utils/formatting'
 import { useLoans } from '../utils/useLoans'
 import { usePool, usePoolMetadata } from '../utils/usePools'
+import { RiskGroupSharesPieChart } from './Charts/RiskGroupSharesPieChart'
 import { Column, DataTable, SortableTableHeader } from './DataTable'
-import { PieChart } from './PieChart'
 
 export type AssetByRiskGroup = {
   color?: string
@@ -197,7 +197,7 @@ export const RiskGroupList: React.FC = () => {
     <>
       {sharesForPie.length > 0 && summaryRow.share !== '0' && (
         <Shelf justifyContent="center">
-          <PieChart data={sharesForPie} />
+          <RiskGroupSharesPieChart data={sharesForPie} />
         </Shelf>
       )}
       {tableDataWithColor.length > 0 ? (

--- a/nft-studio/src/components/RiskGroupList.tsx
+++ b/nft-studio/src/components/RiskGroupList.tsx
@@ -198,7 +198,7 @@ export const RiskGroupList: React.FC = () => {
       color: '',
       labelColor: ' ',
     }
-  }, [riskGroups, remainingAssets, pool?.nav.latest])
+  }, [riskGroups, remainingAssets, pool?.nav.latest, pool?.currency, totalSharesSum])
 
   // biggest share of pie gets darkest color
   const tableDataWithColor = [...riskGroups, ...remainingAssets]

--- a/nft-studio/src/components/RiskGroupList.tsx
+++ b/nft-studio/src/components/RiskGroupList.tsx
@@ -13,11 +13,11 @@ import { Column, DataTable, SortableTableHeader } from './DataTable'
 export type AssetByRiskGroup = {
   color?: string
   labelColor?: string
-  name: string
-  amount: Balance
+  name: string | React.ReactElement
+  amount: Balance | any
   share: string | React.ReactElement
-  interestRatePerSec: string
-  riskAdjustment: string
+  interestRatePerSec: string | React.ReactElement
+  riskAdjustment: string | React.ReactElement
 }
 
 const initialRow: AssetByRiskGroup = {
@@ -146,7 +146,7 @@ export const RiskGroupList: React.FC = () => {
   // temp solution while assets are still manually priced (in the future there will be a select to choose a riskGroup)
   // represents all assets that could not be sorted into a riskGroup
   const remainingAssets: AssetByRiskGroup[] = React.useMemo(() => {
-    const amountsSum = riskGroups.reduce((curr, prev) => new Balance(curr.add(prev.amount)), new Balance('0'))
+    const amountsSum = riskGroups.reduce((curr, prev) => new Balance(curr.add(prev.amount as any)), new Balance('0'))
     const sharesSum = riskGroups.reduce((curr, prev) => curr + Number(prev.share) * 100, 0)
 
     return sharesSum !== 100 && sharesSum !== 0
@@ -180,7 +180,7 @@ export const RiskGroupList: React.FC = () => {
     return {
       share: (
         <Text variant="body2" fontWeight={600}>
-          {totalSharesSum}
+          {totalSharesSum}%
         </Text>
       ),
       amount: (
@@ -193,8 +193,10 @@ export const RiskGroupList: React.FC = () => {
           Total
         </Text>
       ),
-      interestRatePerSec: <Text variant="body2" fontWeight={600}>{`Avg ${avgInterestRatePerSec.toString()}`}</Text>,
-      riskAdjustment: <Text variant="body2" fontWeight={600}>{`Avg. ${avgRiskAdjustment.toString()}`}</Text>,
+      interestRatePerSec: <Text variant="body2" fontWeight={600}>{`Avg ${avgInterestRatePerSec.toString()}%`}</Text>,
+      riskAdjustment: <Text variant="body2" fontWeight={600}>{`Avg. ${avgRiskAdjustment.toString()}%`}</Text>,
+      color: '',
+      labelColor: ' ',
     }
   }, [riskGroups, remainingAssets, pool?.nav.latest])
 
@@ -214,7 +216,7 @@ export const RiskGroupList: React.FC = () => {
     })
 
   const sharesForPie = tableDataWithColor.map(({ name, color, labelColor, share }) => {
-    return { value: Number(share), name, color, labelColor }
+    return { value: Number(share), name: name as string, color, labelColor }
   })
 
   return (

--- a/nft-studio/src/components/RiskGroupList.tsx
+++ b/nft-studio/src/components/RiskGroupList.tsx
@@ -198,7 +198,7 @@ export const RiskGroupList: React.FC = () => {
       color: '',
       labelColor: ' ',
     }
-  }, [riskGroups, remainingAssets, pool?.nav.latest, pool?.currency, totalSharesSum])
+  }, [riskGroups, pool?.nav.latest, pool?.currency, totalSharesSum])
 
   // biggest share of pie gets darkest color
   const tableDataWithColor = [...riskGroups, ...remainingAssets]

--- a/nft-studio/src/components/Tooltips.tsx
+++ b/nft-studio/src/components/Tooltips.tsx
@@ -102,20 +102,26 @@ const tooltipText = {
     title: 'placeholder title',
     body: 'placeholder body',
   },
+  epochTimeRemaining: {
+    label: '',
+    title: 'placeholder title',
+    body: 'placeholder body',
+  },
 }
 
 type TooltipsProps = {
   type: keyof typeof tooltipText
   variant?: 'primary' | 'secondary'
+  dynamicLabel?: string
 }
 
-export const Tooltips: React.VFC<TooltipsProps> = ({ type, variant = 'primary' }) => {
+export const Tooltips: React.VFC<TooltipsProps> = ({ type, dynamicLabel, variant = 'primary' }) => {
   const { label, title, body } = tooltipText[type]
   const isPrimary = variant === 'primary'
   return (
     <FabricTooltip title={title} body={body}>
       <Text textAlign="left" variant="label2" color={isPrimary ? 'textPrimary' : 'textSecondary'}>
-        {label}
+        {dynamicLabel || label}
       </Text>
     </FabricTooltip>
   )

--- a/nft-studio/src/components/Tooltips.tsx
+++ b/nft-studio/src/components/Tooltips.tsx
@@ -112,16 +112,16 @@ const tooltipText = {
 type TooltipsProps = {
   type: keyof typeof tooltipText
   variant?: 'primary' | 'secondary'
-  dynamicLabel?: string
+  label?: string
 }
 
-export const Tooltips: React.VFC<TooltipsProps> = ({ type, dynamicLabel, variant = 'primary' }) => {
+export const Tooltips: React.VFC<TooltipsProps> = ({ type, label: labelOverride, variant = 'primary' }) => {
   const { label, title, body } = tooltipText[type]
   const isPrimary = variant === 'primary'
   return (
     <FabricTooltip title={title} body={body}>
       <Text textAlign="left" variant="label2" color={isPrimary ? 'textPrimary' : 'textSecondary'}>
-        {dynamicLabel || label}
+        {labelOverride || label}
       </Text>
     </FabricTooltip>
   )

--- a/nft-studio/src/components/Tooltips.tsx
+++ b/nft-studio/src/components/Tooltips.tsx
@@ -72,6 +72,36 @@ const tooltipText = {
     title: 'placeholder title',
     body: 'placeholder body',
   },
+  poolReserve: {
+    label: 'Pool reserve',
+    title: 'placeholder title',
+    body: 'placeholder body',
+  },
+  invested30d: {
+    label: 'Invested (30d)',
+    title: 'placeholder title',
+    body: 'placeholder body',
+  },
+  redeemed30d: {
+    label: 'Redeemed (30d)',
+    title: 'placeholder title',
+    body: 'placeholder body',
+  },
+  repaid30d: {
+    label: 'Repaid (30d)',
+    title: 'placeholder title',
+    body: 'placeholder body',
+  },
+  upcomingRepayments30d: {
+    label: 'Upcoming repayments (30d)',
+    title: 'placeholder title',
+    body: 'placeholder body',
+  },
+  cashDrag: {
+    label: 'Cash drag',
+    title: 'placeholder title',
+    body: 'placeholder body',
+  },
 }
 
 type TooltipsProps = {

--- a/nft-studio/src/pages/PoolDetail/Header.tsx
+++ b/nft-studio/src/pages/PoolDetail/Header.tsx
@@ -22,46 +22,42 @@ export const PoolDetailHeader: React.FC<Props> = ({ actions }) => {
   const basePath = `/pools/${pid}`
 
   return (
-    <>
-      <PageHeader
-        title={
-          <TextWithPlaceholder isLoading={isLoading}>{metadata?.pool?.name ?? 'Unnamed pool'}</TextWithPlaceholder>
-        }
-        subtitle={
-          <TextWithPlaceholder isLoading={isLoading}>by {metadata?.pool?.issuer.name ?? 'Unknown'}</TextWithPlaceholder>
-        }
-        icon={
-          metadata?.pool?.icon ? (
-            <Box as="img" width="iconLarge" height="iconLarge" src={parseMetadataUrl(metadata?.pool?.icon)} />
-          ) : (
-            <Shelf
-              width="iconLarge"
-              height="iconLarge"
-              borderRadius="card"
-              backgroundColor={isLoading ? 'borderSecondary' : 'accentSecondary'}
-              justifyContent="center"
-            >
-              <Text variant="body1">{(isLoading ? '' : metadata?.pool?.name ?? 'U')[0]}</Text>
-            </Shelf>
-          )
-        }
-        border={false}
-        actions={actions}
+    <PageHeader
+      title={<TextWithPlaceholder isLoading={isLoading}>{metadata?.pool?.name ?? 'Unnamed pool'}</TextWithPlaceholder>}
+      subtitle={
+        <TextWithPlaceholder isLoading={isLoading}>by {metadata?.pool?.issuer.name ?? 'Unknown'}</TextWithPlaceholder>
+      }
+      icon={
+        metadata?.pool?.icon ? (
+          <Box as="img" width="iconLarge" height="iconLarge" src={parseMetadataUrl(metadata?.pool?.icon)} />
+        ) : (
+          <Shelf
+            width="iconLarge"
+            height="iconLarge"
+            borderRadius="card"
+            backgroundColor={isLoading ? 'borderSecondary' : 'accentSecondary'}
+            justifyContent="center"
+          >
+            <Text variant="body1">{(isLoading ? '' : metadata?.pool?.name ?? 'U')[0]}</Text>
+          </Shelf>
+        )
+      }
+      border={false}
+      actions={actions}
+    >
+      <Shelf
+        px={PAGE_GUTTER}
+        bg={theme.colors.backgroundPrimary}
+        style={{
+          boxShadow: `0 1px 0 ${theme.colors.borderSecondary}`,
+        }}
       >
-        <Shelf
-          px={PAGE_GUTTER}
-          bg={theme.colors.backgroundPrimary}
-          style={{
-            boxShadow: `0 1px 0 ${theme.colors.borderSecondary}`,
-          }}
-        >
-          <NavigationTabs basePath={basePath}>
-            <NavigationTabsItem to={`${basePath}`}>Overview</NavigationTabsItem>
-            <NavigationTabsItem to={`${basePath}/assets`}>Assets</NavigationTabsItem>
-            <NavigationTabsItem to={`${basePath}/liquidity`}>Liquidity</NavigationTabsItem>
-          </NavigationTabs>
-        </Shelf>
-      </PageHeader>
-    </>
+        <NavigationTabs basePath={basePath}>
+          <NavigationTabsItem to={`${basePath}`}>Overview</NavigationTabsItem>
+          <NavigationTabsItem to={`${basePath}/assets`}>Assets</NavigationTabsItem>
+          <NavigationTabsItem to={`${basePath}/liquidity`}>Liquidity</NavigationTabsItem>
+        </NavigationTabs>
+      </Shelf>
+    </PageHeader>
   )
 }

--- a/nft-studio/src/pages/PoolDetail/LiquidityTab/index.tsx
+++ b/nft-studio/src/pages/PoolDetail/LiquidityTab/index.tsx
@@ -10,9 +10,7 @@ import { PageWithSideBar } from '../../../components/PageWithSideBar'
 import { Tooltips } from '../../../components/Tooltips'
 import { getEpochHoursRemaining } from '../../../utils/date'
 import { formatBalance } from '../../../utils/formatting'
-import { useAddress } from '../../../utils/useAddress'
 import { useCentrifugeTransaction } from '../../../utils/useCentrifugeTransaction'
-import { usePermissions } from '../../../utils/usePermissions'
 import { usePool } from '../../../utils/usePools'
 import { PoolDetailHeader } from '../Header'
 
@@ -30,8 +28,6 @@ export const PoolDetailLiquidityTab: React.FC = () => {
 export const PoolDetailLiquidity: React.FC = () => {
   const { pid: poolId } = useParams<{ pid: string }>()
   const pool = usePool(poolId)
-  const address = useAddress()
-  const permissions = usePermissions(address)
 
   // const dailyPoolStates = useDailyPoolStates(poolId)
 
@@ -49,10 +45,6 @@ export const PoolDetailLiquidity: React.FC = () => {
     // { label: <Tooltips type="upcomingRepayments30d" />, value: formatBalance(0, pool.currency) },
   ]
 
-  const isPoolAdmin = React.useMemo(
-    () => !!(address && permissions?.pools[poolId]?.roles.includes('PoolAdmin')),
-    [poolId, address, permissions]
-  )
   const { execute: closeEpochTx } = useCentrifugeTransaction('Close epoch', (cent) => cent.pools.closeEpoch, {
     onSuccess: () => {
       console.log('Epoch closed successfully')
@@ -77,11 +69,9 @@ export const PoolDetailLiquidity: React.FC = () => {
         headerRight={
           <Shelf gap="1">
             <Tooltips type="epochTimeRemaining" dynamicLabel={`${getEpochHoursRemaining(pool!)} hrs remaining`} />
-            {isPoolAdmin && (
-              <Button small variant="secondary" onClick={closeEpoch} disabled={!pool}>
-                Execute
-              </Button>
-            )}
+            <Button small variant="secondary" onClick={closeEpoch} disabled={!pool}>
+              Execute
+            </Button>
           </Shelf>
         }
       >

--- a/nft-studio/src/pages/PoolDetail/LiquidityTab/index.tsx
+++ b/nft-studio/src/pages/PoolDetail/LiquidityTab/index.tsx
@@ -68,7 +68,7 @@ export const PoolDetailLiquidity: React.FC = () => {
         titleAddition={`Ongoing`}
         headerRight={
           <Shelf gap="1">
-            <Tooltips type="epochTimeRemaining" dynamicLabel={`${getEpochHoursRemaining(pool!)} hrs remaining`} />
+            <Tooltips type="epochTimeRemaining" label={`${getEpochHoursRemaining(pool!)} hrs remaining`} />
             <Button small variant="secondary" onClick={closeEpoch} disabled={!pool}>
               Execute
             </Button>

--- a/nft-studio/src/pages/PoolDetail/LiquidityTab/index.tsx
+++ b/nft-studio/src/pages/PoolDetail/LiquidityTab/index.tsx
@@ -1,13 +1,19 @@
+import { Button, Shelf } from '@centrifuge/fabric'
 import * as React from 'react'
 import { useParams } from 'react-router'
 import { ReserveCashDragChart } from '../../../components/Charts/ReserveCashDragChart'
+import { EpochList } from '../../../components/EpochList'
 import { LoadBoundary } from '../../../components/LoadBoundary'
 import { PageSection } from '../../../components/PageSection'
 import { PageSummary } from '../../../components/PageSummary'
 import { PageWithSideBar } from '../../../components/PageWithSideBar'
 import { Tooltips } from '../../../components/Tooltips'
+import { getEpochHoursRemaining } from '../../../utils/date'
 import { formatBalance } from '../../../utils/formatting'
-import { usePool } from '../../../utils/usePools'
+import { useAddress } from '../../../utils/useAddress'
+import { useCentrifugeTransaction } from '../../../utils/useCentrifugeTransaction'
+import { usePermissions } from '../../../utils/usePermissions'
+import { usePool, usePoolMetadata } from '../../../utils/usePools'
 import { PoolDetailHeader } from '../Header'
 
 export const PoolDetailLiquidityTab: React.FC = () => {
@@ -25,20 +31,75 @@ export const PoolDetailLiquidity: React.FC = () => {
   const { pid: poolId } = useParams<{ pid: string }>()
   const pool = usePool(poolId)
   if (!pool) return null
+  const { data: metadata } = usePoolMetadata(pool)
+  const address = useAddress()
+  const permissions = usePermissions(address)
+
+  // const dailyPoolStates = useDailyPoolStates(poolId)
+
+  // const date30DaysAgo = new Date().setDate(new Date().getDate() - 30)
+  // const poolStates30d = dailyPoolStates?.filter((state) => new Date(state.timestamp) > new Date(date30DaysAgo))
 
   const pageSummaryData = [
     { label: <Tooltips type="poolReserve" />, value: formatBalance(pool.reserve.total.toDecimal(), pool.currency) },
-    { label: <Tooltips type="invested30d" />, value: formatBalance(0, pool.currency) },
-    { label: <Tooltips type="redeemed30d" />, value: formatBalance(0, pool.currency) },
-    { label: <Tooltips type="repaid30d" />, value: formatBalance(0, pool.currency) },
-    { label: <Tooltips type="upcomingRepayments30d" />, value: formatBalance(0, pool.currency) },
+    // { label: <Tooltips type="invested30d" />, value: formatBalance(0, pool.currency) },
+    // { label: <Tooltips type="redeemed30d" />, value: formatBalance(0, pool.currency) },
+    // { label: <Tooltips type="repaid30d" />, value: formatBalance(0, pool.currency) },
+    // { label: <Tooltips type="upcomingRepayments30d" />, value: formatBalance(0, pool.currency) },
   ]
+
+  const isPoolAdmin = React.useMemo(
+    () => !!(address && permissions?.pools[poolId]?.roles.includes('PoolAdmin')),
+    [poolId, address, permissions]
+  )
+  const { execute: closeEpochTx } = useCentrifugeTransaction('Close epoch', (cent) => cent.pools.closeEpoch, {
+    onSuccess: () => {
+      console.log('Epoch closed successfully')
+    },
+  })
+
+  const closeEpoch = async () => {
+    if (!pool) return
+    closeEpochTx([pool.id])
+  }
+
+  const investments = pool.tranches.map((token) => {
+    const trancheMeta = metadata?.tranches?.[token.seniority]
+    return {
+      order: `${trancheMeta?.symbol} investments`,
+      locked: token.investFulfillment?.toDecimal(),
+    }
+  })
+
+  const redmetions = pool.tranches.map((token) => {
+    const trancheMeta = metadata?.tranches?.[token.seniority]
+    return {
+      order: `${trancheMeta?.symbol} investments`,
+      locked: token.redeemFulfillment?.toDecimal(),
+    }
+  })
 
   return (
     <>
       <PageSummary data={pageSummaryData} />
       <PageSection title="Reserve vs. cash drag">
         <ReserveCashDragChart />
+      </PageSection>
+      <PageSection
+        title={`Epoch ${pool.epoch.current}`}
+        titleAddition={`Ongoing`}
+        headerRight={
+          <Shelf gap="1">
+            <Tooltips type="epochTimeRemaining" dynamicLabel={`${getEpochHoursRemaining(pool!)} hrs remaining`} />
+            {isPoolAdmin && (
+              <Button small variant="secondary" onClick={closeEpoch} disabled={!pool}>
+                Execute
+              </Button>
+            )}
+          </Shelf>
+        }
+      >
+        <EpochList investments={investments} redmetions={redmetions} />
       </PageSection>
     </>
   )

--- a/nft-studio/src/pages/PoolDetail/LiquidityTab/index.tsx
+++ b/nft-studio/src/pages/PoolDetail/LiquidityTab/index.tsx
@@ -13,12 +13,12 @@ import { formatBalance } from '../../../utils/formatting'
 import { useAddress } from '../../../utils/useAddress'
 import { useCentrifugeTransaction } from '../../../utils/useCentrifugeTransaction'
 import { usePermissions } from '../../../utils/usePermissions'
-import { usePool, usePoolMetadata } from '../../../utils/usePools'
+import { usePool } from '../../../utils/usePools'
 import { PoolDetailHeader } from '../Header'
 
 export const PoolDetailLiquidityTab: React.FC = () => {
   return (
-    <PageWithSideBar sidebar>
+    <PageWithSideBar>
       <PoolDetailHeader />
       <LoadBoundary>
         <PoolDetailLiquidity />
@@ -31,7 +31,6 @@ export const PoolDetailLiquidity: React.FC = () => {
   const { pid: poolId } = useParams<{ pid: string }>()
   const pool = usePool(poolId)
   if (!pool) return null
-  const { data: metadata } = usePoolMetadata(pool)
   const address = useAddress()
   const permissions = usePermissions(address)
 
@@ -63,22 +62,6 @@ export const PoolDetailLiquidity: React.FC = () => {
     closeEpochTx([pool.id])
   }
 
-  const investments = pool.tranches.map((token) => {
-    const trancheMeta = metadata?.tranches?.[token.seniority]
-    return {
-      order: `${trancheMeta?.symbol} investments`,
-      locked: token.investFulfillment?.toDecimal(),
-    }
-  })
-
-  const redmetions = pool.tranches.map((token) => {
-    const trancheMeta = metadata?.tranches?.[token.seniority]
-    return {
-      order: `${trancheMeta?.symbol} investments`,
-      locked: token.redeemFulfillment?.toDecimal(),
-    }
-  })
-
   return (
     <>
       <PageSummary data={pageSummaryData} />
@@ -99,7 +82,7 @@ export const PoolDetailLiquidity: React.FC = () => {
           </Shelf>
         }
       >
-        <EpochList investments={investments} redmetions={redmetions} />
+        <EpochList pool={pool} />
       </PageSection>
     </>
   )

--- a/nft-studio/src/pages/PoolDetail/LiquidityTab/index.tsx
+++ b/nft-studio/src/pages/PoolDetail/LiquidityTab/index.tsx
@@ -30,7 +30,6 @@ export const PoolDetailLiquidityTab: React.FC = () => {
 export const PoolDetailLiquidity: React.FC = () => {
   const { pid: poolId } = useParams<{ pid: string }>()
   const pool = usePool(poolId)
-  if (!pool) return null
   const address = useAddress()
   const permissions = usePermissions(address)
 
@@ -40,7 +39,10 @@ export const PoolDetailLiquidity: React.FC = () => {
   // const poolStates30d = dailyPoolStates?.filter((state) => new Date(state.timestamp) > new Date(date30DaysAgo))
 
   const pageSummaryData = [
-    { label: <Tooltips type="poolReserve" />, value: formatBalance(pool.reserve.total.toDecimal(), pool.currency) },
+    {
+      label: <Tooltips type="poolReserve" />,
+      value: formatBalance(pool?.reserve.total.toDecimal() || 0, pool?.currency || ''),
+    },
     // { label: <Tooltips type="invested30d" />, value: formatBalance(0, pool.currency) },
     // { label: <Tooltips type="redeemed30d" />, value: formatBalance(0, pool.currency) },
     // { label: <Tooltips type="repaid30d" />, value: formatBalance(0, pool.currency) },
@@ -62,6 +64,7 @@ export const PoolDetailLiquidity: React.FC = () => {
     closeEpochTx([pool.id])
   }
 
+  if (!pool) return null
   return (
     <>
       <PageSummary data={pageSummaryData} />

--- a/nft-studio/src/pages/PoolDetail/LiquidityTab/index.tsx
+++ b/nft-studio/src/pages/PoolDetail/LiquidityTab/index.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react'
+import { useParams } from 'react-router'
+import { ReserveCashDragChart } from '../../../components/Charts/ReserveCashDragChart'
 import { LoadBoundary } from '../../../components/LoadBoundary'
+import { PageSection } from '../../../components/PageSection'
+import { PageSummary } from '../../../components/PageSummary'
 import { PageWithSideBar } from '../../../components/PageWithSideBar'
+import { Tooltips } from '../../../components/Tooltips'
+import { formatBalance } from '../../../utils/formatting'
+import { usePool } from '../../../utils/usePools'
 import { PoolDetailHeader } from '../Header'
 
 export const PoolDetailLiquidityTab: React.FC = () => {
@@ -15,5 +22,24 @@ export const PoolDetailLiquidityTab: React.FC = () => {
 }
 
 export const PoolDetailLiquidity: React.FC = () => {
-  return <div>Liquidity</div>
+  const { pid: poolId } = useParams<{ pid: string }>()
+  const pool = usePool(poolId)
+  if (!pool) return null
+
+  const pageSummaryData = [
+    { label: <Tooltips type="poolReserve" />, value: formatBalance(pool.reserve.total.toDecimal(), pool.currency) },
+    { label: <Tooltips type="invested30d" />, value: formatBalance(0, pool.currency) },
+    { label: <Tooltips type="redeemed30d" />, value: formatBalance(0, pool.currency) },
+    { label: <Tooltips type="repaid30d" />, value: formatBalance(0, pool.currency) },
+    { label: <Tooltips type="upcomingRepayments30d" />, value: formatBalance(0, pool.currency) },
+  ]
+
+  return (
+    <>
+      <PageSummary data={pageSummaryData} />
+      <PageSection title="Reserve vs. cash drag">
+        <ReserveCashDragChart />
+      </PageSection>
+    </>
+  )
 }

--- a/nft-studio/src/pages/PoolDetail/OverviewTab/index.tsx
+++ b/nft-studio/src/pages/PoolDetail/OverviewTab/index.tsx
@@ -1,12 +1,12 @@
 import { Button, IconArrowRight, IconChevronLeft } from '@centrifuge/fabric'
 import * as React from 'react'
 import { useHistory, useParams } from 'react-router'
+import { PoolAssetReserveChart } from '../../../components/Charts/PoolAssetReserveChart'
 import { IssuerSection } from '../../../components/IssuerSection'
 import { LoadBoundary } from '../../../components/LoadBoundary'
 import { PageSection } from '../../../components/PageSection'
 import { PageSummary } from '../../../components/PageSummary'
 import { PageWithSideBar } from '../../../components/PageWithSideBar'
-import { ReserveChart } from '../../../components/ReserveChart'
 import { RiskGroupList } from '../../../components/RiskGroupList'
 import { TokenListByPool } from '../../../components/TokenListByPool'
 import { Tooltips } from '../../../components/Tooltips'
@@ -92,7 +92,7 @@ export const PoolDetailOverview: React.FC = () => {
     <>
       <PageSummary data={pageSummaryData} />
       <PageSection title="Pool value, asset value & reserve" titleAddition={formatDate(new Date().toString())}>
-        <ReserveChart />
+        <PoolAssetReserveChart />
       </PageSection>
       <PageSection title="Investment Tokens">
         <TokenListByPool />

--- a/nft-studio/src/pages/PoolDetail/OverviewTab/index.tsx
+++ b/nft-studio/src/pages/PoolDetail/OverviewTab/index.tsx
@@ -1,4 +1,4 @@
-import { Button, IconArrowRight, IconChevronLeft } from '@centrifuge/fabric'
+import { Button, IconChevronLeft } from '@centrifuge/fabric'
 import * as React from 'react'
 import { useHistory, useParams } from 'react-router'
 import { PoolAssetReserveChart } from '../../../components/Charts/PoolAssetReserveChart'
@@ -12,60 +12,20 @@ import { TokenListByPool } from '../../../components/TokenListByPool'
 import { Tooltips } from '../../../components/Tooltips'
 import { formatDate, getAge } from '../../../utils/date'
 import { formatBalance } from '../../../utils/formatting'
-import { useAddress } from '../../../utils/useAddress'
 import { useAverageMaturity } from '../../../utils/useAverageMaturity'
-import { useCentrifugeTransaction } from '../../../utils/useCentrifugeTransaction'
-import { usePermissions } from '../../../utils/usePermissions'
 import { usePool, usePoolMetadata } from '../../../utils/usePools'
 import { PoolDetailHeader } from '../Header'
 
 export const PoolDetailOverviewTab: React.FC = () => {
-  const { pid: poolId } = useParams<{ pid: string }>()
-  const pool = usePool(poolId)
-  const address = useAddress()
-  const permissions = usePermissions(address)
   const history = useHistory()
-
-  const isPoolAdmin = React.useMemo(
-    () => !!(address && permissions?.pools[poolId]?.roles.includes('PoolAdmin')),
-    [poolId, address, permissions]
-  )
-  const { execute: closeEpochTx } = useCentrifugeTransaction('Close epoch', (cent) => cent.pools.closeEpoch, {
-    onSuccess: () => {
-      console.log('Epoch closed successfully')
-    },
-  })
-
-  const closeEpoch = async () => {
-    if (!pool) return
-    closeEpochTx([pool.id])
-  }
 
   return (
     <PageWithSideBar sidebar>
       <PoolDetailHeader
         actions={
-          <>
-            {isPoolAdmin && (
-              <Button
-                small
-                variant="tertiary"
-                icon={<IconArrowRight width="16" />}
-                onClick={closeEpoch}
-                disabled={!pool}
-              >
-                Close epoch
-              </Button>
-            )}
-            <Button
-              onClick={() => history.push('/pools')}
-              small
-              icon={<IconChevronLeft width="16" />}
-              variant="tertiary"
-            >
-              Pools
-            </Button>
-          </>
+          <Button onClick={() => history.push('/pools')} small icon={<IconChevronLeft width="16" />} variant="tertiary">
+            Pools
+          </Button>
         }
       />
       <LoadBoundary>

--- a/nft-studio/src/utils/date.ts
+++ b/nft-studio/src/utils/date.ts
@@ -1,3 +1,5 @@
+import { DetailedPool } from '@centrifuge/centrifuge-js'
+
 export function formatDate(timestamp: number | string) {
   return new Date(timestamp).toLocaleDateString('en-US', {
     year: 'numeric',
@@ -31,4 +33,11 @@ export const getAge = (createdAt: string | undefined | null) => {
   const today = new Date()
   today.setUTCHours(0, 0, 0, 0)
   return formatAge(daysBetween(createdAt || today, today))
+}
+
+export function getEpochHoursRemaining(pool: DetailedPool) {
+  const last = new Date(pool.epoch.lastClosed).getTime()
+  const min = pool.parameters.minEpochTime * 1000
+  const now = Date.now()
+  return Math.ceil(Math.max(0, last + min - now) / (1000 * 60 * 60))
 }


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

<!-- Describe the goal of this pull request and if possible, insight on the implementation choices. -->

This pull request...

- Adds liquidity tab to public pool
- refactors custom chart components for easier reuse

It does not include calculation for 30d sum as they are not yet available via subquery

<!-- This will link the pull request to a Github issue. Remove if there is no corresponding Github issue. -->

Tickets:
#713
#710 (missing some values in the summary b/c they are not available on subgraph yet)
#824


### Approvals

<!-- Depending on the nature of the pull request, remove the roles that are not necessary for this review. Intricate technical changes may require two dev approvals. Reviewers should check the corresponding box after they approve. -->

- [ ] Dev
- [ ] Dev
- [ ] Designer
- [ ] Product

### Screenshots

<!-- Supporting screenshots, gifs, or videos to give reviewers an idea of how the pull request will affect the presentation of the app. -->


![Screenshot 2022-05-16 at 22-28-04 Centrifuge App](https://user-images.githubusercontent.com/24418964/168677031-b7dfb425-6950-4ba1-a2f8-31fdb6490bc1.png)
> firefox messed up the screenshot 😱 

### Impact

<!-- Describe what parts of the app were affected so that reviewers can direct their focus. -->
nft-studio