### PR TITLE
Centrifuge App: Fix finance and repayment forms

### DIFF
--- a/centrifuge-app/src/components/Dialogs/SellDialog.tsx
+++ b/centrifuge-app/src/components/Dialogs/SellDialog.tsx
@@ -18,7 +18,7 @@ type Props = {
 const TRANSFER_FEE_ESTIMATE = 0.1
 
 export const SellDialog: React.FC<Props> = ({ open, onClose, collectionId, nftId }) => {
-  const [price, setPrice] = React.useState<string | number>('')
+  const [price, setPrice] = React.useState<number | ''>()
   const [touched, setTouched] = React.useState(false)
   const { selectedAccount } = useWeb3()
   const balance = useBalance()
@@ -42,7 +42,7 @@ export const SellDialog: React.FC<Props> = ({ open, onClose, collectionId, nftId
   function submit(e: React.FormEvent) {
     e.preventDefault()
     if (!isConnected || !!error) return
-
+    if (!price) return
     const amountBN = new BN(price).mul(e18)
     doTransaction([collectionId, nftId, amountBN])
   }
@@ -82,8 +82,7 @@ export const SellDialog: React.FC<Props> = ({ open, onClose, collectionId, nftId
           <CurrencyInput
             label="Price"
             value={price}
-            min="0"
-            onChange={(e) => setPrice(e.target.value)}
+            handleChange={(value) => setPrice(value)}
             errorMessage={(touched && error) || undefined}
             onBlur={() => setTouched(true)}
             currency="AIR"

--- a/centrifuge-app/src/components/Dialogs/SellDialog.tsx
+++ b/centrifuge-app/src/components/Dialogs/SellDialog.tsx
@@ -82,7 +82,7 @@ export const SellDialog: React.FC<Props> = ({ open, onClose, collectionId, nftId
           <CurrencyInput
             label="Price"
             value={price}
-            handleChange={(value) => setPrice(value)}
+            onChange={(value) => setPrice(value)}
             errorMessage={(touched && error) || undefined}
             onBlur={() => setTouched(true)}
             currency="AIR"

--- a/centrifuge-app/src/components/InvestRedeem.tsx
+++ b/centrifuge-app/src/components/InvestRedeem.tsx
@@ -54,9 +54,6 @@ export const InvestRedeem: React.VFC<Props> = (props) => {
 //   return nums.reduce((a, b) => (a.greaterThan(b) ? b : a))
 // }
 
-function inputToNumber(num: number | Decimal | '') {
-  return num instanceof Decimal ? num.toNumber() : num || 0
-}
 function inputToDecimal(num: number | Decimal | string) {
   return Dec(num || 0)
 }

--- a/centrifuge-app/src/components/InvestRedeem.tsx
+++ b/centrifuge-app/src/components/InvestRedeem.tsx
@@ -260,7 +260,7 @@ const InvestForm: React.VFC<InvestFormProps> = ({ poolId, trancheId, onCancel, h
                 currency={getCurrencySymbol(pool?.currency)}
                 secondaryLabel={pool && balance && `${formatBalance(balance, pool?.currency)} balance`}
                 onSetMax={(setDisplayValue) => {
-                  setDisplayValue(Math.floor(balance.toNumber() * 100) / 100)
+                  setDisplayValue(String(Math.floor(balance.toNumber() * 100) / 100))
                   form.setFieldValue('amount', Math.floor(balance.toNumber() * 100) / 100)
                 }}
               />
@@ -426,7 +426,7 @@ const RedeemForm: React.VFC<RedeemFormProps> = ({ poolId, trancheId, onCancel })
               label="Amount"
               disabled={isLoading || isLoadingCancel}
               onSetMax={(setDisplayValue) => {
-                setDisplayValue(Math.floor(combinedBalance.toNumber() * 100) / 100)
+                setDisplayValue(String(Math.floor(combinedBalance.toNumber() * 100) / 100))
                 form.setFieldValue('amount', Math.floor(combinedBalance.toNumber() * 100) / 100)
               }}
               handleChange={(value: number) => {

--- a/centrifuge-app/src/components/InvestRedeem.tsx
+++ b/centrifuge-app/src/components/InvestRedeem.tsx
@@ -256,7 +256,7 @@ const InvestForm: React.VFC<InvestFormProps> = ({ poolId, trancheId, onCancel, h
             return (
               <CurrencyInput
                 {...field}
-                handleChange={(value) => form.setFieldValue('amount', value)}
+                onChange={(value) => form.setFieldValue('amount', value)}
                 errorMessage={meta.touched ? meta.error : undefined}
                 label={`Amount ${isFirstInvestment ? `(min: ${formatBalance(minInvest, pool?.currency)})` : ''}`}
                 disabled={isLoading || isLoadingCancel}
@@ -429,7 +429,7 @@ const RedeemForm: React.VFC<RedeemFormProps> = ({ poolId, trancheId, onCancel })
               label="Amount"
               disabled={isLoading || isLoadingCancel}
               onSetMax={() => form.setFieldValue('amount', maxRedeem)}
-              handleChange={(value) => form.setFieldValue('amount', value)}
+              onChange={(value) => form.setFieldValue('amount', value)}
               currency={getCurrencySymbol(pool?.currency)}
               secondaryLabel={`${formatBalance(roundDown(maxRedeem), pool?.currency, 2)} available`}
             />

--- a/centrifuge-app/src/components/InvestRedeem.tsx
+++ b/centrifuge-app/src/components/InvestRedeem.tsx
@@ -313,7 +313,7 @@ const InvestForm: React.VFC<InvestFormProps> = ({ poolId, trancheId, onCancel, h
             isCancelling={isLoadingCancel}
             onChangeOrder={() => {
               form.resetForm()
-              form.setFieldValue('amount', pendingInvest.toString(), false)
+              form.setFieldValue('amount', pendingInvest, false)
               setChangeOrderFormShown(true)
             }}
           />

--- a/centrifuge-app/src/components/InvestRedeem.tsx
+++ b/centrifuge-app/src/components/InvestRedeem.tsx
@@ -62,7 +62,6 @@ function validateNumberInput(value: number | string | Decimal, min: number | Dec
   if (value === '') {
     return 'Not a valid number'
   }
-  console.log('🚀 ~ Dec(value)', Dec(value).toString(), Dec(max).toString())
   if (max && Dec(value).greaterThan(Dec(max))) {
     return 'Value too large'
   }

--- a/centrifuge-app/src/components/MaxReserveForm.tsx
+++ b/centrifuge-app/src/components/MaxReserveForm.tsx
@@ -55,7 +55,7 @@ export const MaxReserveForm: React.VFC<Props> = ({ poolId }) => {
                   errorMessage={meta.touched ? meta.error : undefined}
                   disabled={isLoading}
                   currency={getCurrencySymbol(pool?.currency)}
-                  handleChange={(value) => form.setFieldValue('maxReserve', value)}
+                  onChange={(value) => form.setFieldValue('maxReserve', value)}
                 />
               )}
             </Field>

--- a/centrifuge-app/src/components/MaxReserveForm.tsx
+++ b/centrifuge-app/src/components/MaxReserveForm.tsx
@@ -23,9 +23,9 @@ export const MaxReserveForm: React.VFC<Props> = ({ poolId }) => {
     { onSuccess: () => form.resetForm() }
   )
 
-  const form = useFormik<{ maxReserve: string | undefined }>({
+  const form = useFormik<{ maxReserve: number | '' }>({
     initialValues: {
-      maxReserve: undefined,
+      maxReserve: '',
     },
     onSubmit: (values, actions) => {
       if (values.maxReserve) {
@@ -45,21 +45,19 @@ export const MaxReserveForm: React.VFC<Props> = ({ poolId }) => {
         <Text variant="heading3">Maximum reserve</Text>
       </Shelf>
       <FormikProvider value={form}>
-        <Form noValidate>
+        <Form>
           <Stack gap="2">
             <Field name="maxReserve">
-              {({ field, meta, form }: FieldProps) => {
-                return (
-                  <CurrencyInput
-                    {...field}
-                    initialValue={pool?.reserve.max.toDecimal().toNumber()}
-                    errorMessage={meta.touched ? meta.error : undefined}
-                    disabled={isLoading}
-                    currency={getCurrencySymbol(pool?.currency)}
-                    handleChange={(value) => form.setFieldValue('maxReserve', value)}
-                  />
-                )
-              }}
+              {({ field, meta, form }: FieldProps) => (
+                <CurrencyInput
+                  {...field}
+                  initialValue={pool?.reserve.max.toDecimal().toNumber()}
+                  errorMessage={meta.touched ? meta.error : undefined}
+                  disabled={isLoading}
+                  currency={getCurrencySymbol(pool?.currency)}
+                  handleChange={(value) => form.setFieldValue('maxReserve', value)}
+                />
+              )}
             </Field>
             <Button type="submit" loading={isLoading} loadingMessage={'Confirming'}>
               Apply

--- a/centrifuge-app/src/components/MaxReserveForm.tsx
+++ b/centrifuge-app/src/components/MaxReserveForm.tsx
@@ -2,11 +2,12 @@ import { Balance } from '@centrifuge/centrifuge-js'
 import { Button, Card, CurrencyInput, Shelf, Stack, Text } from '@centrifuge/fabric'
 import { Field, FieldProps, Form, FormikProvider, useFormik } from 'formik'
 import * as React from 'react'
-import { getCurrencySymbol } from '../utils/formatting'
+import { formatThousandSeparator, getCurrencySymbol, removeThousandSeparator } from '../utils/formatting'
 import { useAddress } from '../utils/useAddress'
 import { useCentrifugeTransaction } from '../utils/useCentrifugeTransaction'
 import { useLiquidityAdmin } from '../utils/usePermissions'
 import { usePool } from '../utils/usePools'
+import { positiveNumber } from '../utils/validation'
 
 type Props = {
   poolId: string
@@ -23,37 +24,43 @@ export const MaxReserveForm: React.VFC<Props> = ({ poolId }) => {
     { onSuccess: () => form.resetForm() }
   )
 
-  const form = useFormik<{ maxReserve: number }>({
+  const form = useFormik<{ maxReserve: string | undefined }>({
     initialValues: {
-      maxReserve: 0,
+      maxReserve: undefined,
     },
     onSubmit: (values, actions) => {
-      setMaxReserveTx([poolId, Balance.fromFloat(values.maxReserve)])
+      const parsedInput = removeThousandSeparator(values.maxReserve)
+      if (parsedInput) {
+        setMaxReserveTx([poolId, Balance.fromFloat(parsedInput)])
+      } else {
+        actions.setErrors({ maxReserve: 'Invalid number' })
+      }
       actions.setSubmitting(false)
     },
   })
 
   if (!address || !isLiquidityAdmin) return null
+
   return (
     <Stack as={Card} gap={2} p={2} mt={5}>
       <Shelf justifyContent="space-between">
         <Text variant="heading3">Maximum reserve</Text>
       </Shelf>
       <FormikProvider value={form}>
-        <Form>
+        <Form noValidate>
           <Stack gap="2">
-            <Field name="maxReserve" validate={(value: number) => value <= 0 && 'Value too small'}>
-              {({ field: { value, ...fieldProps }, meta }: FieldProps) => (
-                <CurrencyInput
-                  {...fieldProps}
-                  value={value || pool?.reserve.max.toDecimal().toNumber()}
-                  errorMessage={meta.touched ? meta.error : undefined}
-                  type="number"
-                  min="0"
-                  disabled={isLoading}
-                  currency={getCurrencySymbol(pool?.currency)}
-                />
-              )}
+            <Field name="maxReserve" validate={positiveNumber()}>
+              {({ field: { value, ...fieldProps }, meta }: FieldProps) => {
+                return (
+                  <CurrencyInput
+                    {...fieldProps}
+                    value={formatThousandSeparator(value !== undefined ? value : pool?.reserve.max)}
+                    errorMessage={meta.touched ? meta.error : undefined}
+                    disabled={isLoading}
+                    currency={getCurrencySymbol(pool?.currency)}
+                  />
+                )
+              }}
             </Field>
             <Button type="submit" loading={isLoading} loadingMessage={'Confirming'}>
               Apply

--- a/centrifuge-app/src/components/MaxReserveForm.tsx
+++ b/centrifuge-app/src/components/MaxReserveForm.tsx
@@ -2,12 +2,11 @@ import { Balance } from '@centrifuge/centrifuge-js'
 import { Button, Card, CurrencyInput, Shelf, Stack, Text } from '@centrifuge/fabric'
 import { Field, FieldProps, Form, FormikProvider, useFormik } from 'formik'
 import * as React from 'react'
-import { formatThousandSeparator, getCurrencySymbol, removeThousandSeparator } from '../utils/formatting'
+import { getCurrencySymbol } from '../utils/formatting'
 import { useAddress } from '../utils/useAddress'
 import { useCentrifugeTransaction } from '../utils/useCentrifugeTransaction'
 import { useLiquidityAdmin } from '../utils/usePermissions'
 import { usePool } from '../utils/usePools'
-import { positiveNumber } from '../utils/validation'
 
 type Props = {
   poolId: string
@@ -29,9 +28,8 @@ export const MaxReserveForm: React.VFC<Props> = ({ poolId }) => {
       maxReserve: undefined,
     },
     onSubmit: (values, actions) => {
-      const parsedInput = removeThousandSeparator(values.maxReserve)
-      if (parsedInput) {
-        setMaxReserveTx([poolId, Balance.fromFloat(parsedInput)])
+      if (values.maxReserve) {
+        setMaxReserveTx([poolId, Balance.fromFloat(values.maxReserve)])
       } else {
         actions.setErrors({ maxReserve: 'Invalid number' })
       }
@@ -49,15 +47,18 @@ export const MaxReserveForm: React.VFC<Props> = ({ poolId }) => {
       <FormikProvider value={form}>
         <Form noValidate>
           <Stack gap="2">
-            <Field name="maxReserve" validate={positiveNumber()}>
-              {({ field: { value, ...fieldProps }, meta }: FieldProps) => {
+            <Field name="maxReserve">
+              {({ field: { value, ...fieldProps }, meta, form }: FieldProps) => {
                 return (
                   <CurrencyInput
                     {...fieldProps}
-                    value={formatThousandSeparator(value !== undefined ? value : pool?.reserve.max)}
+                    initialValue={pool?.reserve.max.toDecimal().toNumber()}
                     errorMessage={meta.touched ? meta.error : undefined}
                     disabled={isLoading}
                     currency={getCurrencySymbol(pool?.currency)}
+                    handleChange={(value) => {
+                      form.setFieldValue('maxReserve', value)
+                    }}
                   />
                 )
               }}

--- a/centrifuge-app/src/components/MaxReserveForm.tsx
+++ b/centrifuge-app/src/components/MaxReserveForm.tsx
@@ -48,17 +48,15 @@ export const MaxReserveForm: React.VFC<Props> = ({ poolId }) => {
         <Form noValidate>
           <Stack gap="2">
             <Field name="maxReserve">
-              {({ field: { value, ...fieldProps }, meta, form }: FieldProps) => {
+              {({ field, meta, form }: FieldProps) => {
                 return (
                   <CurrencyInput
-                    {...fieldProps}
+                    {...field}
                     initialValue={pool?.reserve.max.toDecimal().toNumber()}
                     errorMessage={meta.touched ? meta.error : undefined}
                     disabled={isLoading}
                     currency={getCurrencySymbol(pool?.currency)}
-                    handleChange={(value) => {
-                      form.setFieldValue('maxReserve', value)
-                    }}
+                    handleChange={(value) => form.setFieldValue('maxReserve', value)}
                   />
                 )
               }}

--- a/centrifuge-app/src/components/RiskGroupList.tsx
+++ b/centrifuge-app/src/components/RiskGroupList.tsx
@@ -141,7 +141,7 @@ const RiskGroupList: React.FC = () => {
   }, [metadata, loans, pool, totalAmountsSum])
 
   const totalSharesSum = riskGroups
-    .reduce((prev, curr) => (typeof curr.share === 'string' ? prev.add(curr.share) : prev), Dec(0))
+    .reduce((prev, curr) => (typeof curr.share === 'string' ? prev.add(curr.share || 0) : prev), Dec(0))
     .toString()
   const summaryRow = React.useMemo(() => {
     const avgInterestRatePerSec = riskGroups

--- a/centrifuge-app/src/pages/CreateLoan.tsx
+++ b/centrifuge-app/src/pages/CreateLoan.tsx
@@ -84,7 +84,7 @@ const CreateLoan: React.FC = () => {
 
           // Doing the redirect via state, so it only happens if the user is still on this
           // page when the transaction completes
-          setRedirect(`/issuers/${poolId}/assets/${loanId}`)
+          setRedirect(`/issuer/${poolId}/assets/${loanId}`)
         }
       },
     }

--- a/centrifuge-app/src/pages/IssuerCreatePool/index.tsx
+++ b/centrifuge-app/src/pages/IssuerCreatePool/index.tsx
@@ -22,7 +22,6 @@ import { PageWithSideBar } from '../../components/PageWithSideBar'
 import { TextWithPlaceholder } from '../../components/TextWithPlaceholder'
 import { Tooltips } from '../../components/Tooltips'
 import { config } from '../../config'
-import { formatThousandSeparator, removeThousandSeparator } from '../../utils/formatting'
 import { getFileDataURI } from '../../utils/getFileDataURI'
 import { useAddress } from '../../utils/useAddress'
 import { useCentrifugeTransaction } from '../../utils/useCentrifugeTransaction'
@@ -76,7 +75,7 @@ export interface PoolFormValues {
   poolName: string
   assetClass: string
   currency: string
-  maxReserve: string | ''
+  maxReserve: number | ''
   epochHours: number | ''
   epochMinutes: number | ''
 
@@ -293,7 +292,7 @@ const CreatePoolForm: React.VFC = () => {
         collectionId,
         tranches,
         currency,
-        Balance.fromFloat(removeThousandSeparator(values.maxReserve)),
+        Balance.fromFloat(values.maxReserve),
         metadataHash,
         writeOffGroups,
       ])
@@ -409,7 +408,7 @@ const CreatePoolForm: React.VFC = () => {
                     placeholder="0"
                     currency={currencies.find((c) => c.value === form.values.currency)?.label}
                     variant="small"
-                    value={formatThousandSeparator(value)}
+                    handleChange={(value) => form.setFieldValue('maxReserve', value)}
                   />
                 )}
               </Field>

--- a/centrifuge-app/src/pages/IssuerCreatePool/index.tsx
+++ b/centrifuge-app/src/pages/IssuerCreatePool/index.tsx
@@ -123,7 +123,7 @@ const initialValues: PoolFormValues = {
   poolName: '',
   assetClass: DEFAULT_ASSET_CLASS,
   currency: DEFAULT_CURRENCY,
-  maxReserve: 0,
+  maxReserve: '',
   epochHours: 23, // in hours
   epochMinutes: 50, // in minutes
 

--- a/centrifuge-app/src/pages/IssuerCreatePool/index.tsx
+++ b/centrifuge-app/src/pages/IssuerCreatePool/index.tsx
@@ -400,9 +400,9 @@ const CreatePoolForm: React.VFC = () => {
             </Box>
             <Box gridColumn="span 2">
               <Field name="maxReserve" validate={validate.maxReserve}>
-                {({ field: { value, ...fieldProps }, form, meta }: FieldProps) => (
+                {({ field, form }: FieldProps) => (
                   <CurrencyInput
-                    {...fieldProps}
+                    {...field}
                     name="maxReserve"
                     label="Initial maximum reserve*"
                     placeholder="0"

--- a/centrifuge-app/src/pages/IssuerCreatePool/index.tsx
+++ b/centrifuge-app/src/pages/IssuerCreatePool/index.tsx
@@ -408,7 +408,7 @@ const CreatePoolForm: React.VFC = () => {
                     placeholder="0"
                     currency={currencies.find((c) => c.value === form.values.currency)?.label}
                     variant="small"
-                    handleChange={(value) => form.setFieldValue('maxReserve', value)}
+                    onChange={(value) => form.setFieldValue('maxReserve', value)}
                   />
                 )}
               </Field>

--- a/centrifuge-app/src/pages/IssuerCreatePool/index.tsx
+++ b/centrifuge-app/src/pages/IssuerCreatePool/index.tsx
@@ -2,9 +2,9 @@ import { Balance, Perquintill, Rate } from '@centrifuge/centrifuge-js'
 import {
   Box,
   Button,
+  CurrencyInput,
   FileUpload,
   Grid,
-  NumberInput,
   Select,
   Shelf,
   Text,
@@ -22,6 +22,7 @@ import { PageWithSideBar } from '../../components/PageWithSideBar'
 import { TextWithPlaceholder } from '../../components/TextWithPlaceholder'
 import { Tooltips } from '../../components/Tooltips'
 import { config } from '../../config'
+import { formatThousandSeparator, removeThousandSeparator } from '../../utils/formatting'
 import { getFileDataURI } from '../../utils/getFileDataURI'
 import { useAddress } from '../../utils/useAddress'
 import { useCentrifugeTransaction } from '../../utils/useCentrifugeTransaction'
@@ -75,7 +76,7 @@ export interface PoolFormValues {
   poolName: string
   assetClass: string
   currency: string
-  maxReserve: number | ''
+  maxReserve: string | ''
   epochHours: number | ''
   epochMinutes: number | ''
 
@@ -292,7 +293,7 @@ const CreatePoolForm: React.VFC = () => {
         collectionId,
         tranches,
         currency,
-        Balance.fromFloat(values.maxReserve),
+        Balance.fromFloat(removeThousandSeparator(values.maxReserve)),
         metadataHash,
         writeOffGroups,
       ])
@@ -399,14 +400,19 @@ const CreatePoolForm: React.VFC = () => {
               </Field>
             </Box>
             <Box gridColumn="span 2">
-              <FieldWithErrorMessage
-                validate={validate.maxReserve}
-                name="maxReserve"
-                as={NumberInput}
-                label="Initial maximum reserve*"
-                placeholder="0"
-                rightElement={currencies.find((c) => c.value === form.values.currency)?.label}
-              />
+              <Field name="maxReserve" validate={validate.maxReserve}>
+                {({ field: { value, ...fieldProps }, form, meta }: FieldProps) => (
+                  <CurrencyInput
+                    {...fieldProps}
+                    name="maxReserve"
+                    label="Initial maximum reserve*"
+                    placeholder="0"
+                    currency={currencies.find((c) => c.value === form.values.currency)?.label}
+                    variant="small"
+                    value={formatThousandSeparator(value)}
+                  />
+                )}
+              </Field>
             </Box>
             {/* <Box gridColumn="span 1">
               <FieldWithErrorMessage

--- a/centrifuge-app/src/pages/Loan/FinanceForm.tsx
+++ b/centrifuge-app/src/pages/Loan/FinanceForm.tsx
@@ -77,7 +77,7 @@ export const FinanceForm: React.VFC<{ loan: LoanType }> = ({ loan }) => {
     BulletLoan:
       'maturityDate' in loan.loanInfo &&
       Dec(daysBetween(loan.originationDate, loan.loanInfo.maturityDate)).gt(0) &&
-      loan.totalRepaid.toDecimal().lt(initialCeiling),
+      loan.totalBorrowed.toDecimal().lt(initialCeiling),
     CreditLine: loan.outstandingDebt.toDecimal().lt(initialCeiling),
   }
 

--- a/centrifuge-app/src/pages/Loan/FinanceForm.tsx
+++ b/centrifuge-app/src/pages/Loan/FinanceForm.tsx
@@ -14,11 +14,11 @@ import { usePool } from '../../utils/usePools'
 import { combine, max, positiveNumber } from '../../utils/validation'
 
 type FinanceValues = {
-  amount: string | Decimal
+  amount: number | '' | Decimal
 }
 
 type RepayValues = {
-  amount: string | Decimal
+  amount: number | '' | Decimal
 }
 
 const SEC_PER_DAY = 24 * 60 * 60

--- a/centrifuge-app/src/pages/Loan/FinanceForm.tsx
+++ b/centrifuge-app/src/pages/Loan/FinanceForm.tsx
@@ -133,7 +133,7 @@ export const FinanceForm: React.VFC<{ loan: LoanType }> = ({ loan }) => {
                     secondaryLabel={`${formatBalance(roundDown(maxBorrow), pool?.currency, 2)} available`}
                     disabled={isFinanceLoading}
                     currency={getCurrencySymbol(pool?.currency)}
-                    handleChange={(value: number) => form.setFieldValue('amount', value)}
+                    onChange={(value: number) => form.setFieldValue('amount', value)}
                     onSetMax={() => form.setFieldValue('amount', maxBorrow)}
                   />
                 )}
@@ -192,7 +192,7 @@ export const FinanceForm: React.VFC<{ loan: LoanType }> = ({ loan }) => {
                       secondaryLabel={`${formatBalance(roundDown(maxRepay), pool?.currency, 2)} available`}
                       disabled={isRepayLoading || isRepayAllLoading}
                       currency={getCurrencySymbol(pool?.currency)}
-                      handleChange={(value) => form.setFieldValue('amount', value)}
+                      onChange={(value) => form.setFieldValue('amount', value)}
                       onSetMax={() => form.setFieldValue('amount', maxRepay)}
                     />
                   )

--- a/centrifuge-app/src/pages/Loan/FinanceForm.tsx
+++ b/centrifuge-app/src/pages/Loan/FinanceForm.tsx
@@ -4,12 +4,7 @@ import Decimal from 'decimal.js-light'
 import { Field, FieldProps, Form, FormikProvider, useFormik } from 'formik'
 import * as React from 'react'
 import { Dec } from '../../utils/Decimal'
-import {
-  formatBalance,
-  formatThousandSeparator,
-  getCurrencySymbol,
-  removeThousandSeparator,
-} from '../../utils/formatting'
+import { formatBalance, getCurrencySymbol } from '../../utils/formatting'
 import { useAddress } from '../../utils/useAddress'
 import { getBalanceDec, useBalances } from '../../utils/useBalances'
 import { useCentrifugeTransaction } from '../../utils/useCentrifugeTransaction'
@@ -77,7 +72,7 @@ export const FinanceForm: React.VFC<{ loan: LoanType }> = ({ loan }) => {
       amount: '',
     },
     onSubmit: (values, actions) => {
-      const amount = Balance.fromFloat(removeThousandSeparator(values.amount))
+      const amount = Balance.fromFloat(values.amount)
       doFinanceTransaction([loan.poolId, loan.id, amount])
       actions.setSubmitting(false)
     },
@@ -89,7 +84,7 @@ export const FinanceForm: React.VFC<{ loan: LoanType }> = ({ loan }) => {
       amount: '',
     },
     onSubmit: (values, actions) => {
-      const amount = Balance.fromFloat(removeThousandSeparator(values.amount))
+      const amount = Balance.fromFloat(values.amount)
       doRepayTransaction([loan.poolId, loan.id, amount])
       actions.setSubmitting(false)
     },
@@ -129,21 +124,19 @@ export const FinanceForm: React.VFC<{ loan: LoanType }> = ({ loan }) => {
                   )
                 )}
               >
-                {({ field: { value, ...fieldProps }, meta }: FieldProps) => (
+                {({ field: { value, ...fieldProps }, meta, form }: FieldProps) => (
                   <CurrencyInput
                     {...fieldProps}
-                    value={
-                      value instanceof Decimal
-                        ? formatThousandSeparator(Math.floor(value.toNumber() * 100) / 100)
-                        : value
-                    }
                     label="Amount"
-                    min="0"
-                    onSetMax={() => financeForm.setFieldValue('amount', maxBorrow)}
                     errorMessage={meta.touched ? meta.error : undefined}
                     secondaryLabel={`${formatBalance(maxBorrow, pool?.currency)} available`}
                     disabled={isFinanceLoading}
                     currency={getCurrencySymbol(pool?.currency)}
+                    handleChange={(value: number) => form.setFieldValue('amount', value)}
+                    onSetMax={(setDisplayValue) => {
+                      setDisplayValue(Math.floor(maxBorrow.toNumber() * 100) / 100)
+                      form.setFieldValue('amount', Math.floor(maxRepay * 100) / 100)
+                    }}
                   />
                 )}
               </Field>
@@ -189,21 +182,20 @@ export const FinanceForm: React.VFC<{ loan: LoanType }> = ({ loan }) => {
                 )}
                 name="amount"
               >
-                {({ field: { value, ...fieldProps }, meta }: FieldProps) => {
+                {({ field: { value, ...fieldProps }, meta, form }: FieldProps) => {
                   return (
                     <CurrencyInput
                       {...fieldProps}
-                      value={
-                        value instanceof Decimal
-                          ? formatThousandSeparator(Math.floor(value.toNumber() * 100) / 100)
-                          : value
-                      }
                       label="Amount"
-                      onSetMax={() => repayForm.setFieldValue('amount', Dec(maxRepay))}
                       errorMessage={meta.touched ? meta.error : undefined}
                       secondaryLabel={`${formatBalance(maxRepay, pool?.currency)} available`}
                       disabled={isRepayLoading || isRepayAllLoading}
                       currency={getCurrencySymbol(pool?.currency)}
+                      handleChange={(value) => form.setFieldValue('amount', value)}
+                      onSetMax={(setDisplayValue) => {
+                        setDisplayValue(Math.floor(maxRepay * 100) / 100)
+                        form.setFieldValue('amount', Math.floor(maxRepay * 100) / 100)
+                      }}
                     />
                   )
                 }}

--- a/centrifuge-app/src/pages/Loan/FinanceForm.tsx
+++ b/centrifuge-app/src/pages/Loan/FinanceForm.tsx
@@ -134,7 +134,7 @@ export const FinanceForm: React.VFC<{ loan: LoanType }> = ({ loan }) => {
                     currency={getCurrencySymbol(pool?.currency)}
                     handleChange={(value: number) => form.setFieldValue('amount', value)}
                     onSetMax={(setDisplayValue) => {
-                      setDisplayValue(Math.floor(maxBorrow.toNumber() * 100) / 100)
+                      setDisplayValue(String(Math.floor(maxBorrow.toNumber() * 100) / 100))
                       form.setFieldValue('amount', Math.floor(maxRepay * 100) / 100)
                     }}
                   />
@@ -193,7 +193,7 @@ export const FinanceForm: React.VFC<{ loan: LoanType }> = ({ loan }) => {
                       currency={getCurrencySymbol(pool?.currency)}
                       handleChange={(value) => form.setFieldValue('amount', value)}
                       onSetMax={(setDisplayValue) => {
-                        setDisplayValue(Math.floor(maxRepay * 100) / 100)
+                        setDisplayValue(String(Math.floor(maxRepay * 100) / 100))
                         form.setFieldValue('amount', Math.floor(maxRepay * 100) / 100)
                       }}
                     />

--- a/centrifuge-app/src/pages/Loan/FinanceForm.tsx
+++ b/centrifuge-app/src/pages/Loan/FinanceForm.tsx
@@ -135,7 +135,7 @@ export const FinanceForm: React.VFC<{ loan: LoanType }> = ({ loan }) => {
                     value={
                       value instanceof Decimal
                         ? formatThousandSeparator(Math.floor(value.toNumber() * 100) / 100)
-                        : formatThousandSeparator(value || '')
+                        : value
                     }
                     label="Amount"
                     min="0"
@@ -196,11 +196,10 @@ export const FinanceForm: React.VFC<{ loan: LoanType }> = ({ loan }) => {
                       value={
                         value instanceof Decimal
                           ? formatThousandSeparator(Math.floor(value.toNumber() * 100) / 100)
-                          : formatThousandSeparator(value || '')
+                          : value
                       }
                       label="Amount"
-                      // min="0"
-                      onSetMax={() => repayForm.setFieldValue('amount', maxRepay)}
+                      onSetMax={() => repayForm.setFieldValue('amount', Dec(maxRepay))}
                       errorMessage={meta.touched ? meta.error : undefined}
                       secondaryLabel={`${formatBalance(maxRepay, pool?.currency)} available`}
                       disabled={isRepayLoading || isRepayAllLoading}

--- a/centrifuge-app/src/pages/Loan/PricingForm.tsx
+++ b/centrifuge-app/src/pages/Loan/PricingForm.tsx
@@ -1,12 +1,11 @@
 import { Balance, Loan as LoanType, LoanInfoInput, Pool, Rate } from '@centrifuge/centrifuge-js'
 import { Button, CurrencyInput, DateInput, Grid, Select, Stack, Text } from '@centrifuge/fabric'
-import Decimal from 'decimal.js-light'
 import { Field, FieldProps, Form, FormikErrors, FormikProvider, useFormik } from 'formik'
 import * as React from 'react'
 import { FieldWithErrorMessage } from '../../components/FieldWithErrorMessage'
 import { PageSection } from '../../components/PageSection'
 import { PageSummary } from '../../components/PageSummary'
-import { formatThousandSeparator, getCurrencySymbol, removeThousandSeparator } from '../../utils/formatting'
+import { getCurrencySymbol } from '../../utils/formatting'
 import { useCentrifugeTransaction } from '../../utils/useCentrifugeTransaction'
 import { useFocusInvalidInput } from '../../utils/useFocusInvalidInput'
 import { usePoolMetadata } from '../../utils/usePools'
@@ -16,7 +15,7 @@ import { LOAN_FIELDS, LOAN_TYPE_LABELS } from './utils'
 
 type PricingFormValues = {
   loanType: 'BulletLoan' | 'CreditLine' | 'CreditLineWithMaturity'
-  value: string | Decimal
+  value: number | ''
   maturityDate: string
   riskGroup: string
 }
@@ -50,7 +49,7 @@ export const PricingForm: React.VFC<{ loan: LoanType; pool: Pool }> = ({ loan, p
     },
     onSubmit: (values, { setSubmitting }) => {
       if (!riskGroup) return
-      const value = Balance.fromFloat(removeThousandSeparator(values.value))
+      const value = Balance.fromFloat(values.value)
       const maturityDate = new Date(form.values.maturityDate).toISOString()
       const ratePerSec = fee!
 
@@ -107,23 +106,18 @@ export const PricingForm: React.VFC<{ loan: LoanType; pool: Pool }> = ({ loan, p
 
   const fields = {
     value: (
-      <Field name="value" validate={combine(required(), positiveNumber(), max(Number.MAX_SAFE_INTEGER))}>
+      <Field key="value" name="value" validate={combine(required(), positiveNumber(), max(Number.MAX_SAFE_INTEGER))}>
         {({ field: { value, ...fieldProps }, meta }: FieldProps) => {
           return (
             <CurrencyInput
               {...fieldProps}
               variant="small"
-              value={
-                value instanceof Decimal
-                  ? formatThousandSeparator(Math.floor(value.toNumber() * 100) / 100)
-                  : formatThousandSeparator(value || '')
-              }
               label="Collateral value*"
               errorMessage={meta.touched ? meta.error : undefined}
               currency={getCurrencySymbol(pool?.currency)}
-              key="value"
               placeholder="0.00"
               name="value"
+              handleChange={(value) => form.setFieldValue('value', value)}
             />
           )
         }}

--- a/centrifuge-app/src/pages/Loan/PricingForm.tsx
+++ b/centrifuge-app/src/pages/Loan/PricingForm.tsx
@@ -107,10 +107,10 @@ export const PricingForm: React.VFC<{ loan: LoanType; pool: Pool }> = ({ loan, p
   const fields = {
     value: (
       <Field key="value" name="value" validate={combine(required(), positiveNumber(), max(Number.MAX_SAFE_INTEGER))}>
-        {({ field: { value, ...fieldProps }, meta }: FieldProps) => {
+        {({ field, meta }: FieldProps) => {
           return (
             <CurrencyInput
-              {...fieldProps}
+              {...field}
               variant="small"
               label="Collateral value*"
               errorMessage={meta.touched ? meta.error : undefined}

--- a/centrifuge-app/src/pages/Loan/PricingForm.tsx
+++ b/centrifuge-app/src/pages/Loan/PricingForm.tsx
@@ -117,7 +117,7 @@ export const PricingForm: React.VFC<{ loan: LoanType; pool: Pool }> = ({ loan, p
               currency={getCurrencySymbol(pool?.currency)}
               placeholder="0.00"
               name="value"
-              handleChange={(value) => form.setFieldValue('value', value)}
+              onChange={(value) => form.setFieldValue('value', value)}
             />
           )
         }}

--- a/centrifuge-app/src/pages/Loan/PricingForm.tsx
+++ b/centrifuge-app/src/pages/Loan/PricingForm.tsx
@@ -1,11 +1,12 @@
 import { Balance, Loan as LoanType, LoanInfoInput, Pool, Rate } from '@centrifuge/centrifuge-js'
-import { Button, DateInput, Grid, NumberInput, Select, Stack, Text } from '@centrifuge/fabric'
+import { Button, CurrencyInput, DateInput, Grid, Select, Stack, Text } from '@centrifuge/fabric'
+import Decimal from 'decimal.js-light'
 import { Field, FieldProps, Form, FormikErrors, FormikProvider, useFormik } from 'formik'
 import * as React from 'react'
 import { FieldWithErrorMessage } from '../../components/FieldWithErrorMessage'
 import { PageSection } from '../../components/PageSection'
 import { PageSummary } from '../../components/PageSummary'
-import { getCurrencySymbol } from '../../utils/formatting'
+import { formatThousandSeparator, getCurrencySymbol, removeThousandSeparator } from '../../utils/formatting'
 import { useCentrifugeTransaction } from '../../utils/useCentrifugeTransaction'
 import { useFocusInvalidInput } from '../../utils/useFocusInvalidInput'
 import { usePoolMetadata } from '../../utils/usePools'
@@ -15,7 +16,7 @@ import { LOAN_FIELDS, LOAN_TYPE_LABELS } from './utils'
 
 type PricingFormValues = {
   loanType: 'BulletLoan' | 'CreditLine' | 'CreditLineWithMaturity'
-  value: number | string
+  value: string | Decimal
   maturityDate: string
   riskGroup: string
 }
@@ -49,7 +50,7 @@ export const PricingForm: React.VFC<{ loan: LoanType; pool: Pool }> = ({ loan, p
     },
     onSubmit: (values, { setSubmitting }) => {
       if (!riskGroup) return
-      const value = Balance.fromFloat(values.value)
+      const value = Balance.fromFloat(removeThousandSeparator(values.value))
       const maturityDate = new Date(form.values.maturityDate).toISOString()
       const ratePerSec = fee!
 
@@ -106,16 +107,27 @@ export const PricingForm: React.VFC<{ loan: LoanType; pool: Pool }> = ({ loan, p
 
   const fields = {
     value: (
-      <FieldWithErrorMessage
-        key="value"
-        as={NumberInput}
-        label="Collateral value*"
-        min="0"
-        placeholder="0.00"
-        name="value"
-        rightElement={getCurrencySymbol(pool.currency)}
-        validate={combine(required(), positiveNumber(), max(Number.MAX_SAFE_INTEGER))}
-      />
+      <Field name="value" validate={combine(required(), positiveNumber(), max(Number.MAX_SAFE_INTEGER))}>
+        {({ field: { value, ...fieldProps }, meta }: FieldProps) => {
+          return (
+            <CurrencyInput
+              {...fieldProps}
+              variant="small"
+              value={
+                value instanceof Decimal
+                  ? formatThousandSeparator(Math.floor(value.toNumber() * 100) / 100)
+                  : formatThousandSeparator(value || '')
+              }
+              label="Collateral value*"
+              errorMessage={meta.touched ? meta.error : undefined}
+              currency={getCurrencySymbol(pool?.currency)}
+              key="value"
+              placeholder="0.00"
+              name="value"
+            />
+          )
+        }}
+      </Field>
     ),
     maturityDate: (
       <FieldWithErrorMessage

--- a/centrifuge-app/src/pages/Loan/RiskGroupValues.tsx
+++ b/centrifuge-app/src/pages/Loan/RiskGroupValues.tsx
@@ -53,7 +53,6 @@ export const RiskGroupValues: React.FC<{
               formatPercentage(lossGivenDefault.toFloat() * probabilityOfDefault.toFloat() * 100)
             }
           />
-          =
         </>
       )}
       {shownFields.includes('discountRate') && (

--- a/centrifuge-app/src/pages/Loan/index.tsx
+++ b/centrifuge-app/src/pages/Loan/index.tsx
@@ -1,7 +1,6 @@
-import { Box, Card, IconNft, InteractiveCard, Shelf, Stack, Text, Thumbnail } from '@centrifuge/fabric'
+import { Box, IconNft, InteractiveCard, Shelf, Stack, Text, Thumbnail } from '@centrifuge/fabric'
 import * as React from 'react'
 import { useHistory, useParams, useRouteMatch } from 'react-router'
-import { CardHeader } from '../../components/CardHeader'
 import { Identity } from '../../components/Identity'
 import { LabelValueStack } from '../../components/LabelValueStack'
 import LoanLabel from '../../components/LoanLabel'
@@ -41,18 +40,9 @@ const LoanSidebar: React.FC = () => {
   const permissions = usePermissions(address)
   const canBorrow = useCanBorrow(pid, aid)
 
-  if (!loan || loan.status === 'Created' || !permissions) return null
+  if (!loan || loan.status === 'Created' || !permissions || !canBorrow) return null
 
-  return canBorrow ? (
-    <FinanceForm loan={loan} />
-  ) : (
-    <Card p={2}>
-      <Stack gap={2}>
-        <CardHeader title="Finance &amp; Repay" />
-        <Text variant="body2">You don&rsquo;t have permission to finance this asset</Text>
-      </Stack>
-    </Card>
-  )
+  return <FinanceForm loan={loan} />
 }
 
 const Loan: React.FC = () => {

--- a/centrifuge-app/src/pages/Loans.tsx
+++ b/centrifuge-app/src/pages/Loans.tsx
@@ -29,7 +29,7 @@ const Loans: React.FC = () => {
         <LoanList
           loans={loans}
           onLoanClicked={(loan) => {
-            history.push(`/${basePath}/${loan.poolId}/assets/${loan.id}`)
+            history.push(`${basePath}/${loan.poolId}/assets/${loan.id}`)
           }}
         />
       )}

--- a/centrifuge-app/src/pages/PoolDetail/AssetsTab/index.tsx
+++ b/centrifuge-app/src/pages/PoolDetail/AssetsTab/index.tsx
@@ -62,7 +62,7 @@ export const PoolDetailAssets: React.FC = () => {
           <LoanList
             loans={loans}
             onLoanClicked={(loan) => {
-              history.push(`/${basePath}/${pool.id}/assets/${loan.id}`)
+              history.push(`${basePath}/${pool.id}/assets/${loan.id}`)
             }}
           />
         </Box>

--- a/centrifuge-app/src/pages/Pools.tsx
+++ b/centrifuge-app/src/pages/Pools.tsx
@@ -33,16 +33,6 @@ const Pools: React.FC = () => {
     )
   }, [tokens])
 
-  const totalInvestmentCapacity = React.useMemo(() => {
-    return (
-      pools
-        ?.map((pool) => ({
-          capacity: pool.reserve.available.toDecimal().toNumber(),
-        }))
-        .reduce((prev, curr) => prev.add(curr.capacity), Dec(0)) ?? Dec(0)
-    )
-  }, [pools])
-
   const pageSummaryData = [
     {
       label: <Tooltips type="tvl" />,

--- a/centrifuge-app/src/pages/Pools.tsx
+++ b/centrifuge-app/src/pages/Pools.tsx
@@ -50,10 +50,6 @@ const Pools: React.FC = () => {
     },
     { label: 'Pools', value: pools?.length || 0 },
     { label: <Tooltips type="tokens" />, value: tokens?.length || 0 },
-    {
-      label: 'Total investment capacity',
-      value: formatBalance(Dec(totalInvestmentCapacity || 0), getCurrencySymbol(config.baseCurrency)),
-    },
   ]
 
   return (

--- a/centrifuge-app/src/pages/Tokens.tsx
+++ b/centrifuge-app/src/pages/Tokens.tsx
@@ -54,16 +54,6 @@ const TokenOverview: React.FC = () => {
     )
   }, [dataTokens])
 
-  const totalInvestmentCapacity = React.useMemo(() => {
-    return (
-      pools
-        ?.map((pool) => ({
-          capacity: pool.reserve.available.toDecimal().toNumber(),
-        }))
-        .reduce((prev, curr) => prev.add(curr.capacity), Dec(0)) ?? Dec(0)
-    )
-  }, [pools])
-
   const pageSummaryData = [
     {
       label: <Tooltips type="tvl" />,

--- a/centrifuge-app/src/pages/Tokens.tsx
+++ b/centrifuge-app/src/pages/Tokens.tsx
@@ -71,10 +71,6 @@ const TokenOverview: React.FC = () => {
     },
     { label: 'Pools', value: pools?.length || 0 },
     { label: <Tooltips type="tokens" />, value: tokens?.length || 0 },
-    {
-      label: 'Total investment capacity',
-      value: formatBalance(Dec(totalInvestmentCapacity || 0), getCurrencySymbol(config.baseCurrency)),
-    },
   ]
 
   return (

--- a/centrifuge-app/src/utils/formatting.ts
+++ b/centrifuge-app/src/utils/formatting.ts
@@ -11,12 +11,12 @@ export function getCurrencySymbol(currency?: string) {
   return (currency && currencySymbols[currency.toLowerCase() as keyof typeof currencySymbols]) || currency || ''
 }
 
-export function formatBalance(amount: Balance | Decimal | number, currency?: string, precise = false) {
+export function formatBalance(amount: Balance | Decimal | number, currency?: string, precision = 0) {
   const formattedAmount = (
     amount instanceof Balance ? amount.toFloat() : amount instanceof Decimal ? amount.toNumber() : amount
   ).toLocaleString('en', {
-    minimumFractionDigits: precise ? 4 : 0,
-    maximumFractionDigits: precise ? 4 : 0,
+    minimumFractionDigits: precision,
+    maximumFractionDigits: precision,
   })
   return currency ? `${formattedAmount} ${getCurrencySymbol(currency)}` : formattedAmount
 }
@@ -47,4 +47,8 @@ export function formatPercentage(amount: Perquintill | Decimal | number, include
     maximumFractionDigits: 2,
   })
   return includeSymbol ? `${formattedAmount}%` : formattedAmount
+}
+
+export function roundDown(float: Decimal | number) {
+  return Math.floor((float instanceof Decimal ? float.toNumber() : float) * 100) / 100
 }

--- a/centrifuge-app/src/utils/formatting.ts
+++ b/centrifuge-app/src/utils/formatting.ts
@@ -48,3 +48,25 @@ export function formatPercentage(amount: Perquintill | Decimal | number, include
   })
   return includeSymbol ? `${formattedAmount}%` : formattedAmount
 }
+
+export function formatThousandSeparator(input: Balance | number | Decimal): string {
+  const balance = input instanceof Balance ? input.toDecimal().toString() : input.toString()
+  const removeNonNumeric = balance.replace(/[^0-9.]/g, '') // remove non-numeric chars except .
+  if (removeNonNumeric.includes('.')) {
+    const decimalIndex = removeNonNumeric.indexOf('.')
+    // add thousand separator only pre-decimal
+    return `${removeNonNumeric.slice(0, decimalIndex).replace(/\B(?=(\d{3})+(?!\d))/g, ',')}${removeNonNumeric.slice(
+      decimalIndex
+    )}`
+  }
+  return removeNonNumeric.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+}
+
+export function removeThousandSeparator(value?: string | Decimal): number {
+  const formattedNumber =
+    value instanceof Decimal
+      ? parseFloat(value.toString()?.replaceAll(',', '') || '')
+      : parseFloat(value?.replaceAll(',', '') || '')
+
+  return formattedNumber
+}

--- a/centrifuge-app/src/utils/formatting.ts
+++ b/centrifuge-app/src/utils/formatting.ts
@@ -48,25 +48,3 @@ export function formatPercentage(amount: Perquintill | Decimal | number, include
   })
   return includeSymbol ? `${formattedAmount}%` : formattedAmount
 }
-
-export function formatThousandSeparator(input: Balance | number | Decimal): string {
-  const balance = input instanceof Balance ? input.toDecimal().toString() : input.toString()
-  const removeNonNumeric = balance.replace(/[^0-9.]/g, '') // remove non-numeric chars except .
-  if (removeNonNumeric.includes('.')) {
-    const decimalIndex = removeNonNumeric.indexOf('.')
-    // add thousand separator only pre-decimal
-    return `${removeNonNumeric.slice(0, decimalIndex).replace(/\B(?=(\d{3})+(?!\d))/g, ',')}${removeNonNumeric.slice(
-      decimalIndex
-    )}`
-  }
-  return removeNonNumeric.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
-}
-
-export function removeThousandSeparator(value?: string | Decimal): number {
-  const formattedNumber =
-    value instanceof Decimal
-      ? parseFloat(value.toString()?.replaceAll(',', '') || '')
-      : parseFloat(value?.replaceAll(',', '') || '')
-
-  return formattedNumber
-}

--- a/centrifuge-app/src/utils/formatting.ts
+++ b/centrifuge-app/src/utils/formatting.ts
@@ -49,6 +49,6 @@ export function formatPercentage(amount: Perquintill | Decimal | number, include
   return includeSymbol ? `${formattedAmount}%` : formattedAmount
 }
 
-export function roundDown(float: Decimal | number) {
-  return Math.floor((float instanceof Decimal ? float.toNumber() : float) * 100) / 100
+export function roundDown(float: Decimal | number, precision: number = 2) {
+  return Math.floor((float instanceof Decimal ? float.toNumber() : float) * 10 ** precision) / 10 ** precision
 }

--- a/centrifuge-app/src/utils/validation/index.ts
+++ b/centrifuge-app/src/utils/validation/index.ts
@@ -1,4 +1,5 @@
 import Decimal from 'decimal.js-light'
+import { removeThousandSeparator } from '../formatting'
 import { getImageDimensions } from '../getImageDimensions'
 
 const isImageFile = (file: any): boolean => file instanceof File && !!file.type.match(/^image\//)
@@ -23,7 +24,7 @@ export const nonNegativeNumber = (err?: CustomError) => (val?: any) => {
 }
 
 export const positiveNumber = (err?: CustomError) => (val?: any) => {
-  const num = val instanceof Decimal ? val.toNumber() : val
+  const num = val instanceof Decimal ? val.toNumber() : typeof val === 'string' ? removeThousandSeparator(val) : val
   return Number.isFinite(num) && num > 0 ? '' : getError(`Value must be positive`, err, num)
 }
 
@@ -31,7 +32,7 @@ export const integer = (err?: CustomError) => (val?: any) =>
   Number.isFinite(val) && Math.floor(val) === val ? '' : getError(`Value must whole number`, err, val)
 
 export const max = (maxValue: number, err?: CustomError) => (val?: any) => {
-  const num = val instanceof Decimal ? val.toNumber() : val
+  const num = val instanceof Decimal ? val.toNumber() : typeof val === 'string' ? removeThousandSeparator(val) : val
   return num <= maxValue ? '' : getError(`Value too large`, err, num)
 }
 

--- a/centrifuge-app/src/utils/validation/index.ts
+++ b/centrifuge-app/src/utils/validation/index.ts
@@ -1,5 +1,4 @@
 import Decimal from 'decimal.js-light'
-import { removeThousandSeparator } from '../formatting'
 import { getImageDimensions } from '../getImageDimensions'
 
 const isImageFile = (file: any): boolean => file instanceof File && !!file.type.match(/^image\//)
@@ -24,7 +23,7 @@ export const nonNegativeNumber = (err?: CustomError) => (val?: any) => {
 }
 
 export const positiveNumber = (err?: CustomError) => (val?: any) => {
-  const num = val instanceof Decimal ? val.toNumber() : typeof val === 'string' ? removeThousandSeparator(val) : val
+  const num = val instanceof Decimal ? val.toNumber() : val
   return Number.isFinite(num) && num > 0 ? '' : getError(`Value must be positive`, err, num)
 }
 
@@ -32,7 +31,7 @@ export const integer = (err?: CustomError) => (val?: any) =>
   Number.isFinite(val) && Math.floor(val) === val ? '' : getError(`Value must whole number`, err, val)
 
 export const max = (maxValue: number, err?: CustomError) => (val?: any) => {
-  const num = val instanceof Decimal ? val.toNumber() : typeof val === 'string' ? removeThousandSeparator(val) : val
+  const num = val instanceof Decimal ? val.toNumber() : val
   return num <= maxValue ? '' : getError(`Value too large`, err, num)
 }
 

--- a/centrifuge-js/src/modules/pools.ts
+++ b/centrifuge-js/src/modules/pools.ts
@@ -136,7 +136,7 @@ type CreditLineWithMaturity = {
   lossGivenDefault: Rate
 }
 
-type LoanInfo = BulletLoan | CreditLine | CreditLineWithMaturity
+export type LoanInfo = BulletLoan | CreditLine | CreditLineWithMaturity
 
 type TrancheDetailsData = {
   trancheType:

--- a/fabric/src/components/CurrencyInput/CurrencyInput.stories.tsx
+++ b/fabric/src/components/CurrencyInput/CurrencyInput.stories.tsx
@@ -19,6 +19,6 @@ Default.args = {
   disabled: false,
   currency: 'kUSD',
   value: 123456.0,
-  handleChange: () => {},
+  onChange: () => {},
   onSetMax: () => {},
 }

--- a/fabric/src/components/CurrencyInput/CurrencyInput.stories.tsx
+++ b/fabric/src/components/CurrencyInput/CurrencyInput.stories.tsx
@@ -18,5 +18,7 @@ Default.args = {
   errorMessage: '',
   disabled: false,
   currency: 'kUSD',
+  value: 123456.0,
+  handleChange: () => {},
   onSetMax: () => {},
 }

--- a/fabric/src/components/CurrencyInput/index.tsx
+++ b/fabric/src/components/CurrencyInput/index.tsx
@@ -5,13 +5,14 @@ import { InputBox, InputBoxProps } from '../InputBox'
 import { Shelf } from '../Shelf'
 import { Text } from '../Text'
 
-export type CurrencyInputProps = React.InputHTMLAttributes<HTMLInputElement> &
+export type CurrencyInputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> &
   Omit<InputBoxProps, 'inputElement' | 'rightElement'> & {
     currency?: string
     onSetMax?: () => void
     variant?: 'small' | 'large'
-    handleChange?: (value: number) => void
+    onChange?: (value: number) => void
     initialValue?: number
+    precision?: number
   }
 
 const StyledTextInput = styled.input<{ $variant: 'small' | 'large' }>`
@@ -93,6 +94,7 @@ export const CurrencyInput: React.FC<CurrencyInputProps> = ({
   placeholder = '0.0',
   variant = 'large',
   initialValue,
+  precision = 2,
   ...inputProps
 }) => {
   const [value, setValue] = React.useState(initialValue ? formatThousandSeparator(initialValue) : '')
@@ -100,14 +102,16 @@ export const CurrencyInput: React.FC<CurrencyInputProps> = ({
   const onChange = (value: string) => {
     const inputFormatted = formatThousandSeparator(value)
     const inputAsNumber = parseFloat(value.replaceAll(',', ''))
-    if (inputProps?.handleChange) {
-      inputProps?.handleChange(inputAsNumber)
+    if (inputProps?.onChange) {
+      inputProps?.onChange(inputAsNumber)
       setValue(inputFormatted)
     }
   }
 
   React.useEffect(() => {
-    const inputFormatted = formatThousandSeparator(Math.floor((inputProps.value as number) * 100) / 100)
+    const inputFormatted = formatThousandSeparator(
+      Math.floor((inputProps.value as number) * 10 ** precision) / 10 ** precision
+    )
     setValue(inputFormatted)
   }, [inputProps.value])
 

--- a/fabric/src/components/CurrencyInput/index.tsx
+++ b/fabric/src/components/CurrencyInput/index.tsx
@@ -8,7 +8,7 @@ import { Text } from '../Text'
 export type CurrencyInputProps = React.InputHTMLAttributes<HTMLInputElement> &
   Omit<InputBoxProps, 'inputElement' | 'rightElement'> & {
     currency?: string
-    onSetMax?: (setDisplayValue: (value: number | string) => void) => void
+    onSetMax?: () => void
     variant?: 'small' | 'large'
     handleChange?: (value: number) => void
     initialValue?: number
@@ -70,6 +70,7 @@ StyledMaxButton.defaultProps = {
   type: 'button',
 }
 
+// regex from https://stackoverflow.com/questions/63091317/thousand-separator-input-with-react-hooks
 function formatThousandSeparator(input: number | string): string {
   const removeNonNumeric = (typeof input === 'string' ? input : input.toString()).replace(/[^0-9.]/g, '') // remove non-numeric chars except .
   if (removeNonNumeric.includes('.')) {
@@ -104,6 +105,12 @@ export const CurrencyInput: React.FC<CurrencyInputProps> = ({
       setValue(inputFormatted)
     }
   }
+
+  React.useEffect(() => {
+    const inputFormatted = formatThousandSeparator(inputProps.value as number)
+    onChange(inputFormatted)
+  }, [inputProps.value])
+
   return (
     <InputBox
       label={label}
@@ -111,9 +118,7 @@ export const CurrencyInput: React.FC<CurrencyInputProps> = ({
         <Shelf justifyContent="space-between">
           <span>{secondaryLabel}</span>
           {onSetMax && (
-            // the value we display to users is a parse string but the value stored in the form handler is a numeric value
-            // after setting the max make sure you manually overwrite the display value using the onChange handler
-            <StyledMaxButton onClick={() => onSetMax(onChange)} disabled={disabled}>
+            <StyledMaxButton onClick={onSetMax} disabled={disabled}>
               <Text variant="label3" lineHeight={1.5} color="inherit">
                 MAX
               </Text>

--- a/fabric/src/components/CurrencyInput/index.tsx
+++ b/fabric/src/components/CurrencyInput/index.tsx
@@ -83,6 +83,10 @@ function formatThousandSeparator(input: number | string): string {
   return removeNonNumeric.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
 }
 
+/**
+ *
+ * CurrencyInput formats
+ */
 export const CurrencyInput: React.FC<CurrencyInputProps> = ({
   label,
   secondaryLabel,
@@ -107,8 +111,8 @@ export const CurrencyInput: React.FC<CurrencyInputProps> = ({
   }
 
   React.useEffect(() => {
-    const inputFormatted = formatThousandSeparator(inputProps.value as number)
-    onChange(inputFormatted)
+    const inputFormatted = formatThousandSeparator(Math.floor((inputProps.value as number) * 100) / 100)
+    setValue(inputFormatted)
   }, [inputProps.value])
 
   return (

--- a/fabric/src/components/CurrencyInput/index.tsx
+++ b/fabric/src/components/CurrencyInput/index.tsx
@@ -83,10 +83,6 @@ function formatThousandSeparator(input: number | string): string {
   return removeNonNumeric.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
 }
 
-/**
- *
- * CurrencyInput formats
- */
 export const CurrencyInput: React.FC<CurrencyInputProps> = ({
   label,
   secondaryLabel,

--- a/fabric/src/components/CurrencyInput/index.tsx
+++ b/fabric/src/components/CurrencyInput/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { Box } from '../Box'
 import { InputBox, InputBoxProps } from '../InputBox'
 import { Shelf } from '../Shelf'
@@ -9,9 +9,10 @@ export type CurrencyInputProps = React.InputHTMLAttributes<HTMLInputElement> &
   Omit<InputBoxProps, 'inputElement' | 'rightElement'> & {
     currency?: string
     onSetMax?: () => void
+    variant?: 'small' | 'large'
   }
 
-const StyledTextInput = styled.input`
+const StyledTextInput = styled.input<{ $variant: 'small' | 'large' }>`
   width: 100%;
   border: 0;
   background: transparent;
@@ -36,6 +37,13 @@ const StyledTextInput = styled.input`
     -webkit-appearance: none;
     margin: 0;
   }
+
+  ${({ $variant }) =>
+    $variant === 'small' &&
+    css({
+      fontSize: '16px',
+      height: '20px',
+    })}
 `
 
 const StyledMaxButton = styled(Box)`
@@ -68,6 +76,7 @@ export const CurrencyInput: React.FC<CurrencyInputProps> = ({
   currency,
   onSetMax,
   placeholder = '0.0',
+  variant = 'large',
   ...inputProps
 }) => {
   return (
@@ -87,9 +96,15 @@ export const CurrencyInput: React.FC<CurrencyInputProps> = ({
       }
       disabled={disabled}
       errorMessage={errorMessage}
-      inputElement={<StyledTextInput disabled={disabled} placeholder={placeholder} type="number" {...inputProps} />}
+      inputElement={
+        <StyledTextInput disabled={disabled} placeholder={placeholder} type="text" {...inputProps} $variant={variant} />
+      }
       rightElement={
-        <Text variant="body1" color={disabled ? 'textDisabled' : 'textPrimary'}>
+        <Text
+          variant="body1"
+          color={disabled ? 'textDisabled' : 'textPrimary'}
+          fontSize={variant === 'small' ? '16px' : '24px'}
+        >
           {currency}
         </Text>
       }


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

<!-- Describe the goal of this pull request and if possible, insight on the implementation choices. -->

This pull request...
- updates all currency inputs with thousand separator
    - invest form (with max button)
    - redeem form (with max button)
    - finance form (with max button)
    - repay form (with max button)
    - create pool --> initial max reserve field
    - price asset --> collateral value field
    - sell asset --> price field
- rounds max button input down to 2 decimal places
- adds decimals to invest/redeem/finance/repayment forms to avoid losing precision on max button press
- fixes some broken (back)links
- removes the `=` in the pricing form (#874)
- implements change requests in #846 and #844
- allows financing after the asset has been fully financed and repaid (#886) 

<!-- This will link the pull request to a Github issue. Remove if there is no corresponding Github issue. -->

#846 
#844
#874
#886 

### Approvals

<!-- Depending on the nature of the pull request, remove the roles that are not necessary for this review. Intricate technical changes may require two dev approvals. Reviewers should check the corresponding box after they approve. -->

- [ ] Dev


