### PR TITLE
Centrifuge App: Get token prices via RPC

### DIFF
--- a/centrifuge-app/src/components/InvestRedeem.tsx
+++ b/centrifuge-app/src/components/InvestRedeem.tsx
@@ -89,7 +89,7 @@ const InvestRedeemInner: React.VFC<Props> = ({ poolId, trancheId }) => {
   const trancheBalance =
     balances?.tranches.find((t) => t.poolId === poolId && t.trancheId === trancheId)?.balance.toDecimal() ?? Dec(0)
 
-  const price = tranche?.tokenPrice.toDecimal() ?? Dec(0)
+  const price = tranche?.tokenPrice?.toDecimal() ?? Dec(0)
   const investToCollect = order?.payoutTokenAmount.toDecimal() ?? Dec(0)
   const pendingRedeem = order?.remainingRedeemToken.toDecimal() ?? Dec(0)
   const combinedBalance = trancheBalance.add(investToCollect).add(pendingRedeem)
@@ -187,7 +187,7 @@ const InvestForm: React.VFC<InvestFormProps> = ({ poolId, trancheId, onCancel, h
 
   if (pool && !tranche) throw new Error('Nonexistent tranche')
 
-  const price = tranche?.tokenPrice.toDecimal() ?? Dec(0)
+  const price = tranche?.tokenPrice?.toDecimal() ?? Dec(0)
 
   const {
     execute: doInvestTransaction,
@@ -352,7 +352,7 @@ const RedeemForm: React.VFC<RedeemFormProps> = ({ poolId, trancheId, onCancel })
   const pendingRedeem = order?.remainingRedeemToken.toDecimal() ?? Dec(0)
 
   const combinedBalance = trancheBalance.add(investToCollect).add(pendingRedeem)
-  const price = tranche?.tokenPrice.toDecimal() ?? Dec(0)
+  const price = tranche?.tokenPrice?.toDecimal() ?? Dec(0)
   const maxRedeem = combinedBalance.mul(price)
   const tokenSymbol = trancheMeta?.symbol ?? ''
 

--- a/centrifuge-app/src/components/InvestmentsList.tsx
+++ b/centrifuge-app/src/components/InvestmentsList.tsx
@@ -88,7 +88,7 @@ const TokenValue: React.VFC<{ investment: TrancheBalance }> = ({ investment }) =
 
   return (
     <Text variant="body2">
-      {formatBalance(investment.balance.toFloat() * (tranche?.tokenPrice.toFloat() ?? 1), pool?.currency)}
+      {formatBalance(investment.balance.toFloat() * (tranche?.tokenPrice?.toFloat() ?? 1), pool?.currency)}
     </Text>
   )
 }

--- a/centrifuge-app/src/pages/Pools.tsx
+++ b/centrifuge-app/src/pages/Pools.tsx
@@ -27,7 +27,10 @@ const Pools: React.FC = () => {
     return (
       tokens
         ?.map((tranche) => ({
-          valueLocked: tranche.totalIssuance.toDecimal().mul(tranche.tokenPrice.toDecimal()).toNumber(),
+          valueLocked: tranche.totalIssuance
+            .toDecimal()
+            .mul(tranche.tokenPrice?.toDecimal() ?? Dec(0))
+            .toNumber(),
         }))
         .reduce((prev, curr) => prev.add(curr.valueLocked), Dec(0)) ?? Dec(0)
     )

--- a/centrifuge-app/src/pages/Tokens.tsx
+++ b/centrifuge-app/src/pages/Tokens.tsx
@@ -37,7 +37,10 @@ const TokenOverview: React.FC = () => {
             // Use this formula when prices can be fetched: https://docs.centrifuge.io/learn/terms/#30d-drop-yield
             yield: tranche.interestRatePerSec ? tranche.interestRatePerSec.toAprPercent().toNumber() : null,
             protection: tranche.minRiskBuffer?.toPercent().toNumber() || new Perquintill(0).toPercent().toNumber(),
-            valueLocked: tranche.totalIssuance.toDecimal().mul(tranche.tokenPrice.toDecimal()).toNumber(),
+            valueLocked: tranche.totalIssuance
+              .toDecimal()
+              .mul(tranche.tokenPrice?.toDecimal() ?? Dec(0))
+              .toNumber(),
           }
         })
         .flat() || [],
@@ -48,7 +51,10 @@ const TokenOverview: React.FC = () => {
     return (
       dataTokens
         ?.map((tranche) => ({
-          valueLocked: tranche.totalIssuance.toDecimal().mul(tranche.tokenPrice.toDecimal()).toNumber(),
+          valueLocked: tranche.totalIssuance
+            .toDecimal()
+            .mul(tranche.tokenPrice?.toDecimal() ?? Dec(0))
+            .toNumber(),
         }))
         .reduce((prev, curr) => prev.add(curr.valueLocked), Dec(0)) ?? Dec(0)
     )

--- a/centrifuge-js/src/CentrifugeBase.ts
+++ b/centrifuge-js/src/CentrifugeBase.ts
@@ -59,6 +59,21 @@ const parachainTypes = {
   InstanceId: 'u128',
 }
 
+const parachainRpcMethods = {
+  pools: {
+    trancheTokenPrices: {
+      description: 'Retrieve prices for all tranches',
+      params: [
+        {
+          name: 'pool_id',
+          type: 'u64',
+        },
+      ],
+      type: 'Vec<u128>',
+    },
+  },
+}
+
 type Events = ISubmittableResult['events']
 
 const txCompletedEvents: Record<string, Subject<Events>> = {}
@@ -203,11 +218,11 @@ export class CentrifugeBase {
   }
 
   getApi() {
-    return getPolkadotApi(this.parachainUrl, parachainTypes)
+    return getPolkadotApi(this.parachainUrl, parachainTypes, parachainRpcMethods)
   }
 
   getApiPromise() {
-    return firstValueFrom(getPolkadotApi(this.parachainUrl, parachainTypes))
+    return firstValueFrom(getPolkadotApi(this.parachainUrl, parachainTypes, parachainRpcMethods))
   }
 
   getRelayChainApi() {

--- a/centrifuge-js/src/utils/web3.ts
+++ b/centrifuge-js/src/utils/web3.ts
@@ -1,14 +1,19 @@
 import { ApiRx, WsProvider } from '@polkadot/api'
-import { RegistryTypes } from '@polkadot/types/types'
+import { DefinitionRpc, DefinitionRpcSub, RegistryTypes } from '@polkadot/types/types'
 import { Observable } from 'rxjs'
 
 const cached: { [key: string]: Observable<ApiRx> } = {}
-export function getPolkadotApi(wsUrl: string, types?: RegistryTypes) {
+export function getPolkadotApi(
+  wsUrl: string,
+  types?: RegistryTypes,
+  rpc?: Record<string, Record<string, DefinitionRpc | DefinitionRpcSub>>
+) {
   return (
     cached[wsUrl] ||
     (cached[wsUrl] = ApiRx.create({
       provider: new WsProvider(wsUrl),
       types,
+      rpc,
     }))
   )
 }


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

Get token prices via RPC so they're more up to date. We currently get them from the latest epoch, so it's usually out of date. It needs to do a rpc call per pool. It does this in parallel with the rest of the pool data, but allows the pool to emit it's first value without having to wait for all the requests to finish. A side-effect of this is that `tokenPrice` can be `null` in the returned data and you can visually see the TVL increase as data loads on the Pools/Tokens page.

### Approvals

<!-- Depending on the nature of the pull request, remove the roles that are not necessary for this review. Intricate technical changes may require two dev approvals. Reviewers should check the corresponding box after they approve. -->

- [ ] Dev

### Screenshots

<!-- Supporting screenshots, gifs, or videos to give reviewers an idea of how the pull request will affect the presentation of the app. -->

### Impact

CentrifugeJS, Centrifuge App
