### PR TITLE
Centrifuge App: Fix pools refetching

### DIFF
--- a/centrifuge-js/src/modules/pools.ts
+++ b/centrifuge-js/src/modules/pools.ts
@@ -770,7 +770,15 @@ export function getPoolsModule(inst: CentrifugeBase) {
 
     const $events = inst.getEvents().pipe(
       filter(({ api, events }) => {
-        const event = events.find(({ event }) => api.events.pools.Created.is(event))
+        const event = events.find(
+          ({ event }) =>
+            api.events.pools.Created.is(event) ||
+            api.events.pools.Updated.is(event) ||
+            api.events.pools.MaxReserveSet.is(event) ||
+            api.events.pools.MetadataSet.is(event) ||
+            api.events.pools.EpochClosed.is(event) ||
+            api.events.pools.EpochExecuted.is(event)
+        )
         return !!event
       })
     )
@@ -830,7 +838,7 @@ export function getPoolsModule(inst: CentrifugeBase) {
           pools.map((p) => api.rpc.pools.trancheTokenPrices(p.id).pipe(startWith(null))) as Observable<Codec[] | null>[]
         )
 
-        const $issuance = api.query.ormlTokens.totalIssuance.multi(issuanceKeys)
+        const $issuance = api.query.ormlTokens.totalIssuance.multi(issuanceKeys).pipe(take(1))
         return combineLatest([$issuance, $prices]).pipe(
           map(([rawIssuances, rawPrices]) => {
             const mappedPools = pools.map((poolObj, poolIndex) => {


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

Checks for more events when refetching pools, so pools now also get refetching when the max reserve gets set, the epoch is closed, etc.

### Approvals

<!-- Depending on the nature of the pull request, remove the roles that are not necessary for this review. Intricate technical changes may require two dev approvals. Reviewers should check the corresponding box after they approve. -->

- [ ] Dev

### Screenshots

<!-- Supporting screenshots, gifs, or videos to give reviewers an idea of how the pull request will affect the presentation of the app. -->

### Impact

Centrifuge App
