### PR TITLE
CentrifugeJS: Add error handling for insufficient native balances

### DIFF
--- a/centrifuge-app/src/components/InvestRedeem.tsx
+++ b/centrifuge-app/src/components/InvestRedeem.tsx
@@ -30,6 +30,7 @@ import { useCentrifugeTransaction } from '../utils/useCentrifugeTransaction'
 import { useFocusInvalidInput } from '../utils/useFocusInvalidInput'
 import { usePermissions } from '../utils/usePermissions'
 import { usePendingCollect, usePool, usePoolMetadata } from '../utils/usePools'
+import { useTransactionFeeEstimate } from '../utils/useTransactionFeeEstimate'
 import { positiveNumber } from '../utils/validation'
 import { useDebugFlags } from './DebugFlags'
 import { LoadBoundary } from './LoadBoundary'
@@ -213,12 +214,11 @@ const InvestForm: React.VFC<InvestFormProps> = ({ poolId, trancheId, onCancel, h
     },
   })
 
-  // submit dummy tx with paymentInfo option to check how much the tx would cost
-  const { execute: getTxInvestFee, txFee: investTxFee } = useCentrifugeTransaction(
-    'Get tx fee',
+  const { execute: getTxInvestFee, txFee: investTxFee } = useTransactionFeeEstimate(
     (cent) => cent.pools.updateInvestOrder
   )
   React.useEffect(() => {
+    // submit dummy tx with paymentInfo option to get tx fee estimate
     getTxInvestFee([poolId, trancheId, Balance.fromFloat(100)], {
       paymentInfo: address,
     })

--- a/centrifuge-app/src/components/InvestRedeem.tsx
+++ b/centrifuge-app/src/components/InvestRedeem.tsx
@@ -222,7 +222,8 @@ const InvestForm: React.VFC<InvestFormProps> = ({ poolId, trancheId, onCancel, h
     getTxInvestFee([poolId, trancheId, Balance.fromFloat(100)], {
       paymentInfo: address,
     })
-  }, [])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [poolId, trancheId, address])
 
   const { execute: doCancel, isLoading: isLoadingCancel } = useCentrifugeTransaction(
     'Cancel order',

--- a/centrifuge-app/src/components/InvestRedeem.tsx
+++ b/centrifuge-app/src/components/InvestRedeem.tsx
@@ -218,12 +218,9 @@ const InvestForm: React.VFC<InvestFormProps> = ({ poolId, trancheId, onCancel, h
     (cent) => cent.pools.updateInvestOrder
   )
   React.useEffect(() => {
-    // submit dummy tx with paymentInfo option to get tx fee estimate
-    getTxInvestFee([poolId, trancheId, Balance.fromFloat(100)], {
-      paymentInfo: address,
-    })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [poolId, trancheId, address])
+    // submit dummy tx to get tx fee estimate
+    getTxInvestFee([poolId, trancheId, Balance.fromFloat(100)])
+  }, [poolId, trancheId, getTxInvestFee])
 
   const { execute: doCancel, isLoading: isLoadingCancel } = useCentrifugeTransaction(
     'Cancel order',

--- a/centrifuge-app/src/components/InvestRedeem.tsx
+++ b/centrifuge-app/src/components/InvestRedeem.tsx
@@ -278,8 +278,11 @@ const InvestForm: React.VFC<InvestFormProps> = ({ poolId, trancheId, onCancel, h
         {pool?.epoch.isInSubmissionPeriod && epochBusyElement}
         {nativeBalanceTooLow && (
           <InlineFeedback>
-            You need at least {investTxFee?.toFixed(4)} {balances?.native.symbol || config.baseCurrency} to make this
-            transaction.
+            {investTxFee
+              ? `This transaction will cost ${investTxFee.toFixed(4)} ${
+                  balances?.native.symbol || config.baseCurrency
+                }. Please check your balance.`
+              : `${balances?.native.symbol || config.baseCurrency} balance is too low.`}
           </InlineFeedback>
         )}
         <Field name="amount" validate={positiveNumber()}>

--- a/centrifuge-app/src/react-app-env.d.ts
+++ b/centrifuge-app/src/react-app-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="react-scripts" />

--- a/centrifuge-app/src/utils/useCentrifugeTransaction.ts
+++ b/centrifuge-app/src/utils/useCentrifugeTransaction.ts
@@ -86,7 +86,11 @@ export function useCentrifugeTransaction<T extends Array<any>>(
       }
     } catch (e) {
       console.error(e)
-      updateTransaction(id, { status: 'failed', failedReason: 'Failed to submit transaction' })
+      const failedReason = (e as Error).message.includes('[cent-js]')
+        ? (e as Error).message.replaceAll('[cent-js] ', '')
+        : 'Failed to submit transaction'
+
+      updateTransaction(id, { status: 'failed', failedReason })
       options.onError?.(e)
     }
   }

--- a/centrifuge-app/src/utils/useCentrifugeTransaction.ts
+++ b/centrifuge-app/src/utils/useCentrifugeTransaction.ts
@@ -86,11 +86,8 @@ export function useCentrifugeTransaction<T extends Array<any>>(
       }
     } catch (e) {
       console.error(e)
-      const failedReason = (e as Error).message.includes('[cent-js]')
-        ? (e as Error).message.replaceAll('[cent-js] ', '')
-        : 'Failed to submit transaction'
 
-      updateTransaction(id, { status: 'failed', failedReason })
+      updateTransaction(id, { status: 'failed', failedReason: (e as Error).message })
       options.onError?.(e)
     }
   }

--- a/centrifuge-app/src/utils/useCentrifugeTransaction.ts
+++ b/centrifuge-app/src/utils/useCentrifugeTransaction.ts
@@ -8,7 +8,7 @@ import { Transaction, useTransaction, useTransactions } from '../components/Tran
 import { useWeb3 } from '../components/Web3Provider'
 import { PalletError } from './errors'
 
-type TxOptions = Pick<TransactionOptions, 'propose' | 'paymentInfo'>
+type TxOptions = Pick<TransactionOptions, 'propose'>
 
 export function useCentrifugeTransaction<T extends Array<any>>(
   title: string,
@@ -19,7 +19,6 @@ export function useCentrifugeTransaction<T extends Array<any>>(
   const { selectedAccount, connect, proxy } = useWeb3()
   const cent = useCentrifuge()
   const [lastId, setLastId] = React.useState<string | undefined>(undefined)
-  const [txFee, setTxFee] = React.useState<number | undefined>(undefined)
   const lastCreatedTransaction = useTransaction(lastId)
   const pendingTransaction = React.useRef<{ id: string; args: T; options?: TxOptions }>()
 
@@ -80,12 +79,6 @@ export function useCentrifugeTransaction<T extends Array<any>>(
         })
       )
 
-      if (txOptions?.paymentInfo) {
-        const txFee = Number(lastResult.partialFee.toString()) / 10 ** (api.registry.chainDecimals as any)
-        setTxFee(txFee)
-        return
-      }
-
       if (txError) {
         options.onError?.(txError)
       } else {
@@ -99,7 +92,7 @@ export function useCentrifugeTransaction<T extends Array<any>>(
     }
   }
 
-  async function execute(args: T, options?: TxOptions) {
+  function execute(args: T, options?: TxOptions) {
     const id = Math.random().toString(36).substr(2)
     const tx: Transaction = {
       id,
@@ -116,10 +109,6 @@ export function useCentrifugeTransaction<T extends Array<any>>(
         updateTransaction(id, { status: 'failed', failedReason: e.message })
       })
     } else {
-      if (options?.paymentInfo) {
-        const paymentInfo = await doTransaction(selectedAccount, id, args, options)
-        return paymentInfo
-      }
       doTransaction(selectedAccount, id, args, options)
     }
     return id
@@ -142,7 +131,6 @@ export function useCentrifugeTransaction<T extends Array<any>>(
   return {
     execute,
     lastCreatedTransaction,
-    txFee,
     reset: () => setLastId(undefined),
     isLoading: lastCreatedTransaction
       ? ['creating', 'unconfirmed', 'pending'].includes(lastCreatedTransaction.status)

--- a/centrifuge-app/src/utils/useTransactionFeeEstimate.ts
+++ b/centrifuge-app/src/utils/useTransactionFeeEstimate.ts
@@ -26,8 +26,7 @@ export function useTransactionFeeEstimate<T extends Array<any>>(
           ...txOptions,
         })
       )
-
-      const txFee = Number(lastResult.partialFee.toString()) / 10 ** (api.registry.chainDecimals as any)
+      const txFee = lastResult.partialFee.toDecimal()
       setTxFee(txFee)
     } catch (e) {
       console.error(e)

--- a/centrifuge-app/src/utils/useTransactionFeeEstimate.ts
+++ b/centrifuge-app/src/utils/useTransactionFeeEstimate.ts
@@ -25,6 +25,7 @@ export function useTransactionFeeEstimate<T extends Array<any>>(
 
       const lastResult = await lastValueFrom(
         transaction(args, {
+          paymentInfo: selectedAccount.address,
           ...txOptions,
         })
       )

--- a/centrifuge-app/src/utils/useTransactionFeeEstimate.ts
+++ b/centrifuge-app/src/utils/useTransactionFeeEstimate.ts
@@ -1,27 +1,51 @@
-import { ApiRx } from '@polkadot/api'
-import { SubmittableExtrinsic } from '@polkadot/api/types'
+import Centrifuge, { TransactionOptions } from '@centrifuge/centrifuge-js'
+import { WalletAccount } from '@talisman-connect/wallets'
 import * as React from 'react'
-import { useQuery } from 'react-query'
+import { lastValueFrom, Observable } from 'rxjs'
 import { useCentrifuge } from '../components/CentrifugeProvider'
 import { useWeb3 } from '../components/Web3Provider'
 
-export function useTransactionFeeEstimate(callback: (api: ApiRx) => SubmittableExtrinsic<'promise'>) {
-  const { selectedAccount } = useWeb3()
-  const cent = useCentrifuge()
-  const [key] = React.useState(() => Math.random().toString(36).substr(2))
-  const query = useQuery(
-    ['fee', key],
-    async () => {
-      const api = await cent.getApiPromise()
-      const submittable = callback(api)
-      const feeResponse = await submittable.paymentInfo(selectedAccount!.address)
-      return Number(feeResponse.partialFee.toString()) / 10 ** (api.registry.chainDecimals as any)
-    },
-    {
-      enabled: !!selectedAccount,
-      cacheTime: 0, // delete the data when unmounting
-    }
-  )
+type TxOptions = Pick<TransactionOptions, 'paymentInfo'>
 
-  return query
+export function useTransactionFeeEstimate<T extends Array<any>>(
+  transactionCallback: (centrifuge: Centrifuge) => (args: T, options: TransactionOptions) => Observable<any>
+) {
+  const { selectedAccount, proxy } = useWeb3()
+  const cent = useCentrifuge()
+  const [txFee, setTxFee] = React.useState<number | undefined>(undefined)
+
+  async function doTransaction(selectedAccount: WalletAccount, args: T, txOptions?: TxOptions) {
+    try {
+      const connectedCent = cent.connect(selectedAccount?.address, selectedAccount?.signer as any)
+      if (proxy) {
+        connectedCent.setProxy(proxy.delegator)
+      }
+      const api = await cent.getApiPromise()
+      const transaction = transactionCallback(connectedCent)
+
+      const lastResult = await lastValueFrom(
+        transaction(args, {
+          ...txOptions,
+        })
+      )
+
+      const txFee = Number(lastResult.partialFee.toString()) / 10 ** (api.registry.chainDecimals as any)
+      setTxFee(txFee)
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  async function execute(args: T, options?: TxOptions) {
+    if (!selectedAccount) {
+      return
+    } else {
+      await doTransaction(selectedAccount, args, options)
+    }
+  }
+
+  return {
+    execute,
+    txFee,
+  }
 }

--- a/centrifuge-app/src/utils/useTransactionFeeEstimate.ts
+++ b/centrifuge-app/src/utils/useTransactionFeeEstimate.ts
@@ -40,9 +40,8 @@ export function useTransactionFeeEstimate<T extends Array<any>>(
   async function execute(args: T, options?: TxOptions) {
     if (!selectedAccount) {
       return
-    } else {
-      await doTransaction(selectedAccount, args, options)
     }
+    await doTransaction(selectedAccount, args, options)
   }
 
   return {

--- a/centrifuge-app/src/utils/useTransactionFeeEstimate.ts
+++ b/centrifuge-app/src/utils/useTransactionFeeEstimate.ts
@@ -10,16 +10,13 @@ type TxOptions = Pick<TransactionOptions, 'paymentInfo'>
 export function useTransactionFeeEstimate<T extends Array<any>>(
   transactionCallback: (centrifuge: Centrifuge) => (args: T, options: TransactionOptions) => Observable<any>
 ) {
-  const { selectedAccount, proxy } = useWeb3()
+  const { selectedAccount } = useWeb3()
   const cent = useCentrifuge()
   const [txFee, setTxFee] = React.useState<number | undefined>(undefined)
 
   async function doTransaction(selectedAccount: WalletAccount, args: T, txOptions?: TxOptions) {
     try {
       const connectedCent = cent.connect(selectedAccount?.address, selectedAccount?.signer as any)
-      if (proxy) {
-        connectedCent.setProxy(proxy.delegator)
-      }
       const api = await cent.getApiPromise()
       const transaction = transactionCallback(connectedCent)
 

--- a/centrifuge-js/src/CentrifugeBase.ts
+++ b/centrifuge-js/src/CentrifugeBase.ts
@@ -46,6 +46,12 @@ export type Config = {
 
 export type UserProvidedConfig = Partial<Config>
 
+export type PaymentInfo = {
+  class: string
+  partialFee: number
+  weight: number
+}
+
 const defaultConfig: Config = {
   network: 'centrifuge',
   centrifugeWsUrl: 'wss://fullnode.centrifuge.io',
@@ -138,8 +144,12 @@ export class CentrifugeBase {
       if (options?.paymentInfo) {
         return lastValueFrom(
           $paymentInfo.pipe(
-            map((paymentInfo) => {
-              return paymentInfo.toJSON()
+            map((paymentInfoRaw) => {
+              const paymentInfo = paymentInfoRaw.toJSON() as PaymentInfo
+              return {
+                ...paymentInfo,
+                partialFee: new Balance(paymentInfo.partialFee),
+              }
             })
           )
         )

--- a/centrifuge-js/src/CentrifugeBase.ts
+++ b/centrifuge-js/src/CentrifugeBase.ts
@@ -1,10 +1,12 @@
 import { ApiRx } from '@polkadot/api'
 import { AddressOrPair, SubmittableExtrinsic } from '@polkadot/api/types'
 import { ISubmittableResult, Signer } from '@polkadot/types/types'
+import { hexToBn } from '@polkadot/util'
 import 'isomorphic-fetch'
 import {
   bufferCount,
   catchError,
+  combineLatest,
   combineLatestWith,
   filter,
   firstValueFrom,
@@ -16,11 +18,13 @@ import {
   startWith,
   Subject,
   switchMap,
+  take,
   takeWhile,
   tap,
   throwError,
 } from 'rxjs'
 import { fromFetch } from 'rxjs/fetch'
+import { Balance } from '.'
 import { TransactionOptions } from './types'
 import { getPolkadotApi } from './utils/web3'
 
@@ -120,29 +124,49 @@ export class CentrifugeBase {
     }
 
     const { signer, signingAddress } = this.getSigner()
-    if (options?.paymentInfo) {
-      return submittable.paymentInfo(options.paymentInfo)
-    }
+
     try {
       let actualSubmittable = submittable
       if (this.config.proxy) {
         actualSubmittable = api.tx.proxy.proxy(this.config.proxy, undefined, submittable)
       }
-      return actualSubmittable.signAndSend(signingAddress, { signer }).pipe(
-        tap((result) => {
-          options?.onStatusChange?.(result)
-          if (result.status.isInBlock) this.getTxCompletedEvents().next(result.events)
-        }),
-        takeWhile((result) => {
-          const errors = result.events.filter(({ event }) => api.events.system.ExtrinsicFailed.is(event))
-          if (errors.length && this.config.debug) {
-            console.log('🚨 error', JSON.stringify(errors))
-          }
-          const hasError = !!(result.dispatchError || errors.length)
 
-          return !result.status.isInBlock && !hasError
-        }, true)
-      )
+      const $paymentInfo = submittable.paymentInfo(signingAddress)
+      const $balances = api.query.system.account(signingAddress)
+
+      return combineLatest([$balances, $paymentInfo])
+        .pipe(
+          take(1),
+          takeWhile(([balancesRaw, paymentInfoRaw]) => {
+            const paymentInfo = paymentInfoRaw.toJSON() as any
+            const nativeBalance = balancesRaw.toJSON() as any
+            const txFee = Number(paymentInfo.partialFee.toString()) / 10 ** (api.registry.chainDecimals as any)
+            const balance = new Balance(hexToBn(nativeBalance.data.free))
+            if (balance.lten(txFee)) {
+              throw new Error(`[cent-js] ${api.registry.chainTokens[0]} balance too low`)
+            }
+            return true
+          })
+        )
+        .pipe(
+          switchMap(() =>
+            actualSubmittable.signAndSend(signingAddress, { signer }).pipe(
+              tap((result) => {
+                options?.onStatusChange?.(result)
+                if (result.status.isInBlock) this.getTxCompletedEvents().next(result.events)
+              }),
+              takeWhile((result) => {
+                const errors = result.events.filter(({ event }) => api.events.system.ExtrinsicFailed.is(event))
+                if (errors.length && this.config.debug) {
+                  console.log('🚨 error', JSON.stringify(errors))
+                }
+                const hasError = !!(result.dispatchError || errors.length)
+
+                return !result.status.isInBlock && !hasError
+              }, true)
+            )
+          )
+        )
     } catch (e) {
       return throwError(() => e)
     }

--- a/centrifuge-js/src/CentrifugeBase.ts
+++ b/centrifuge-js/src/CentrifugeBase.ts
@@ -143,7 +143,7 @@ export class CentrifugeBase {
             const txFee = Number(paymentInfo.partialFee.toString()) / 10 ** (api.registry.chainDecimals as any)
             const balance = new Balance(hexToBn(nativeBalance.data.free))
             if (balance.lten(txFee)) {
-              throw new Error(`[cent-js] ${api.registry.chainTokens[0]} balance too low`)
+              throw new Error(`${api.registry.chainTokens[0]} balance too low`)
             }
             return true
           })

--- a/centrifuge-js/src/CentrifugeBase.ts
+++ b/centrifuge-js/src/CentrifugeBase.ts
@@ -48,7 +48,7 @@ export type UserProvidedConfig = Partial<Config>
 
 export type PaymentInfo = {
   class: string
-  partialFee: number
+  partialFee: number | Balance
   weight: number
 }
 


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

<!-- Describe the goal of this pull request and if possible, insight on the implementation choices. -->

This pull request... 
- stops the transaction before signing if the native balance is too low. It sends error message into toast (before `sendAndSign` is called on any tx, we make sure the native token balance is greater than the estimated fee)
- adds the possibility to get the tx fee from `useCentrifugeTransaction` so it can be displayed to the user. For now I've only implemented it in the invest form.

<!-- This will link the pull request to a Github issue. Remove if there is no corresponding Github issue. -->

#929 

### Approvals

<!-- Depending on the nature of the pull request, remove the roles that are not necessary for this review. Intricate technical changes may require two dev approvals. Reviewers should check the corresponding box after they approve. -->

- [ ] Dev
- [ ] Dev
- [ ] Designer
- [ ] Product

### Screenshots

<!-- Supporting screenshots, gifs, or videos to give reviewers an idea of how the pull request will affect the presentation of the app. -->

### Impact

<!-- Describe what parts of the app were affected so that reviewers can direct their focus. -->
