### PR TITLE
removes not used .env.*  references

### DIFF
--- a/centrifuge-app/.gitignore
+++ b/centrifuge-app/.gitignore
@@ -13,10 +13,7 @@
 
 # misc
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
### Description
Removes all not used references to .env files. These were confusing to me, as we only use one single .env file. .env is ignored already on root level of the mono repo, but leaving it in place to make sure it will never end up getting pushed.

### Approvals
- [ ] Dev