### PR TITLE
Adds feature flag to hide newly created pools

### DIFF
--- a/centrifuge-app/src/components/DebugFlags/config.ts
+++ b/centrifuge-app/src/components/DebugFlags/config.ts
@@ -29,6 +29,7 @@ export type Key =
   | 'alternativeTheme'
   | 'editPoolConfig'
   | 'poolReporting'
+  | 'editPoolVisibility'
 
 export const flagsConfig: Record<Key, DebugFlagConfig> = {
   address: {
@@ -66,5 +67,10 @@ export const flagsConfig: Record<Key, DebugFlagConfig> = {
   showUnusedFlags: {
     type: 'checkbox',
     default: false,
+  },
+  editPoolVisibility: {
+    type: 'checkbox',
+    default: false,
+    alwaysShow: true,
   },
 }

--- a/centrifuge-app/src/pages/IssuerPool/Configuration/Details.tsx
+++ b/centrifuge-app/src/pages/IssuerPool/Configuration/Details.tsx
@@ -6,6 +6,7 @@ import { useParams } from 'react-router'
 import { lastValueFrom } from 'rxjs'
 import { ButtonGroup } from '../../../components/ButtonGroup'
 import { useCentrifuge } from '../../../components/CentrifugeProvider'
+import { useDebugFlags } from '../../../components/DebugFlags'
 import { FieldWithErrorMessage } from '../../../components/FieldWithErrorMessage'
 import { LabelValueStack } from '../../../components/LabelValueStack'
 import { PageSection } from '../../../components/PageSection'
@@ -34,6 +35,7 @@ export const Details: React.FC = () => {
   const cent = useCentrifuge()
   const prefetchMetadata = usePrefetchMetadata()
   const { data: iconFile } = useFile(metadata?.pool?.icon?.uri, 'icon')
+  const { editPoolVisibility } = useDebugFlags()
 
   const initialValues: Values = React.useMemo(
     () => ({
@@ -191,13 +193,18 @@ export const Details: React.FC = () => {
                 placeholder="https://..."
               />
 
-              <Field name="listed" validate={validate.assetClass}>
-                {({ field, meta, form }: FieldProps) => (
-                  <Stack px={2}>
-                    <LabelValueStack label="Menu listing" value={<Checkbox {...field} label="Published" />} />
-                  </Stack>
-                )}
-              </Field>
+              {!!editPoolVisibility && (
+                <Field name="listed" validate={validate.assetClass}>
+                  {({ field, meta, form }: FieldProps) => (
+                    <Stack px={2}>
+                      <LabelValueStack
+                        label="Menu listing"
+                        value={<Checkbox {...field} checked={field.value} label="Published" />}
+                      />
+                    </Stack>
+                  )}
+                </Field>
+              )}
             </Grid>
           ) : (
             <Shelf gap={3} flexWrap="wrap">

--- a/centrifuge-js/src/modules/pools.ts
+++ b/centrifuge-js/src/modules/pools.ts
@@ -447,6 +447,7 @@ export interface PoolMetadataInput {
   epochHours: number | ''
   epochMinutes: number | ''
   podEndpoint: string
+  listed: boolean
 
   // issuer
   issuerName: string
@@ -715,7 +716,7 @@ export function getPoolsModule(inst: Centrifuge) {
           website: metadata.website,
         },
         status: 'open',
-        listed: true,
+        listed: false,
       },
       pod: {
         url: metadata.podEndpoint ?? null,


### PR DESCRIPTION
### Description
- by default, any newly created pool is unlisted (listed: false)
- for the admin of the pool, it does also show up on the Investments tab, but not for anyone else
- don’t show the option to mark a pool as listed except through a feature flag

Closes 1118

### Approvals
- [ ] Dev
