### PR TITLE
GH Actions: Include Faucet API on demo deploys

### DIFF
--- a/.github/workflows/demo-deploys.yml
+++ b/.github/workflows/demo-deploys.yml
@@ -22,3 +22,9 @@ jobs:
     secrets: inherit
     with:
       deploy_env: demo
+
+  faucet-demo:
+    uses: ./.github/workflows/faucet-api.yml
+    secrets: inherit
+    with:
+      deploy_env: demo

--- a/.github/workflows/faucet-api.yml
+++ b/.github/workflows/faucet-api.yml
@@ -77,5 +77,5 @@ jobs:
           GSA: ${{ secrets.GSA }}
           target: ${{ env.function_handler }}
           gcloud_region: ${{ vars.GCLOUD_REGION }}
-          service_account: '${{ vars.ONBOARDING_FUNCT_SA }}'
+          service_account: '${{ vars.FIRESTORE_SA }}'
           deploy_env: ${{ env.deploy_to }}

--- a/.github/workflows/faucet-api.yml
+++ b/.github/workflows/faucet-api.yml
@@ -10,19 +10,16 @@ on:
     paths:
       - 'faucet-api/**'
       - '.github/workflows/faucet-api.yml'
-  workflow_dispatch:
-    # inputs:
-    #   deploy_env:
-    #     type: choice
-    #     required: true
-    #     default: demo
-    #     options:
-    #       - demo
-    #       - others
+  workflow_call:
+    inputs:
+      deploy_env:
+        type: string
+        required: false
+        default: demo
 env:
   app_name: faucet-api
-  # For now deploy only on demo when triggered manually:
-  deploy_to: ${{ github.event_name == 'workflow_dispatch' && 'demo' || '' }}
+  # For now deploy only on demo when triggered with workflow_call:
+  deploy_to: ${{ inputs.deploy_env && 'demo' || '' }}
   # deploy_to: ${{ inputs_deploy_env }}
   function_handler: faucetDev
 concurrency:


### PR DESCRIPTION
* Include Faucet-api when deploying to demo
* Force deployment to demo regardless of deploy_to var passed to faucet-api (deploy only demo and dev)