### PR TITLE
always show invest card in sidebar

### DIFF
--- a/centrifuge-app/src/components/InvestRedeem/InvestRedeem.tsx
+++ b/centrifuge-app/src/components/InvestRedeem/InvestRedeem.tsx
@@ -178,6 +178,7 @@ function InvestRedeemInner({ view, setView, setTrancheId }: InnerProps) {
   const pool = usePool(state.poolId)
   const history = useHistory()
   const { data: metadata } = usePoolMetadata(pool)
+  const { showWallets, connectedType } = useWallet()
 
   let actualView = view
   if (state.order) {
@@ -195,12 +196,16 @@ function InvestRedeemInner({ view, setView, setTrancheId }: InnerProps) {
         <Box pb={1}>
           <Thumbnail type="token" size="large" label={state.trancheCurrency?.symbol ?? ''} />
         </Box>
-        <TextWithPlaceholder variant="heading3" isLoading={state.isDataLoading}>
-          {formatBalance(state.investmentValue, state.poolCurrency?.symbol)}
-        </TextWithPlaceholder>
-        <TextWithPlaceholder variant="body3" isLoading={state.isDataLoading} width={12} variance={0}>
-          {formatBalance(state.trancheBalanceWithPending, state.trancheCurrency?.symbol)}
-        </TextWithPlaceholder>
+        {connectedType && (
+          <>
+            <TextWithPlaceholder variant="heading3" isLoading={state.isDataLoading}>
+              {formatBalance(state.investmentValue, state.poolCurrency?.symbol)}
+            </TextWithPlaceholder>
+            <TextWithPlaceholder variant="body3" isLoading={state.isDataLoading} width={12} variance={0}>
+              {formatBalance(state.trancheBalanceWithPending, state.trancheCurrency?.symbol)}
+            </TextWithPlaceholder>
+          </>
+        )}
         <Box bleedX={2} mt={1} alignSelf="stretch">
           <Divider borderColor="borderSecondary" />
         </Box>
@@ -219,7 +224,7 @@ function InvestRedeemInner({ view, setView, setTrancheId }: InnerProps) {
           onChange={(event) => setTrancheId(event.target.value as any)}
         />
       )}
-      {state.isDataLoading ? (
+      {connectedType && state.isDataLoading ? (
         <Spinner />
       ) : state.isAllowedToInvest ? (
         <>
@@ -271,8 +276,16 @@ function InvestRedeemInner({ view, setView, setTrancheId }: InnerProps) {
             </AnchorTextLink>
           </Text>
           <Stack px={1}>
-            <Button onClick={() => history.push(`/onboarding?poolId=${state.poolId}&trancheId=${state.trancheId}`)}>
-              Onboard to {state.trancheCurrency?.symbol ?? 'token'}
+            <Button
+              onClick={() => {
+                if (!connectedType) {
+                  showWallets()
+                } else {
+                  history.push(`/onboarding?poolId=${state.poolId}&trancheId=${state.trancheId}`)
+                }
+              }}
+            >
+              {connectedType ? `Onboard to ${state.trancheCurrency?.symbol ?? 'token'}` : 'Connect to invest'}
             </Button>
           </Stack>
         </Stack>

--- a/centrifuge-react/src/components/WalletProvider/ConnectionGuard.tsx
+++ b/centrifuge-react/src/components/WalletProvider/ConnectionGuard.tsx
@@ -19,6 +19,10 @@ export function ConnectionGuard({ networks, children, body = 'Unsupported networ
     connect,
   } = useWallet()
 
+  if (!connectedNetwork) {
+    return <>{children}</>
+  }
+
   if (connectedNetwork && networks.includes(connectedNetwork)) return <>{children}</>
 
   function switchNetwork(target: Network) {


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

<!-- Describe the goal of this pull request and if possible, insight on the implementation choices. -->

This pull request:
- always displays the invest card in the sidebar of the pool overview page with corresponding text in the button
- hides faucet card when user is connected to EVM wallet or viewing a Tinlake pool

### Approvals

<!-- Depending on the nature of the pull request, remove the roles that are not necessary for this review. Intricate technical changes may require two dev approvals. Reviewers should check the corresponding box after they approve. -->

- [x] Dev