### PR TITLE
New pool issuer website field -> required

### DIFF
--- a/centrifuge-app/src/pages/IssuerCreatePool/IssuerInput.tsx
+++ b/centrifuge-app/src/pages/IssuerCreatePool/IssuerInput.tsx
@@ -76,7 +76,7 @@ export const IssuerInput: React.FC<Props> = ({ waitingForStoredIssuer = false })
       <FieldWithErrorMessage
         name="website"
         as={TextInput}
-        label="Website"
+        label="Website*"
         placeholder="https://..."
         validate={validate.website}
       />

--- a/centrifuge-app/src/pages/IssuerCreatePool/validate.ts
+++ b/centrifuge-app/src/pages/IssuerCreatePool/validate.ts
@@ -34,7 +34,7 @@ export const validate = {
   issuerDescription: combine(minLength(100), maxLength(1000)),
   issuerLogo: combineAsync(imageFile(), maxFileSize(1 * MB), maxImageSize(480, 480)),
   executiveSummary: combine(required(), mimeType('application/pdf'), maxFileSize(5 * MB)),
-  website: pattern(/^https?:\/\/.{4,}/, 'Not a valid URL'),
+  website: combine(required(), pattern(/^https?:\/\/.{4,}/, 'Not a valid URL')),
   forum: pattern(/^https?:\/\/.{4,}/, 'Not a valid URL'),
   email: combine(pattern(/@/, 'Not a valid email address'), required()),
   issuerDetailTitle: combine(required(), maxLength(50)),


### PR DESCRIPTION
### Description
When creating a pool the issuer email address in the issuer section has to be mandatory as well as website. This Pr only updates the 'website' field as required, as the email field is required already.

Ticket: https://app.zenhub.com/workspaces/centrifuge-applications-5fa29e924059e5001625e2a3/issues/gh/centrifuge/apps/1204


### Approvals
- [ ] Dev
- [ ] Product

