### PR TITLE
Display abbreviated in wallet menu

### DIFF
--- a/centrifuge-react/src/components/WalletMenu/WalletMenu.tsx
+++ b/centrifuge-react/src/components/WalletMenu/WalletMenu.tsx
@@ -18,7 +18,7 @@ import * as React from 'react'
 import { useBalances } from '../../hooks/useBalances'
 import { useEns } from '../../hooks/useEns'
 import { copyToClipboard } from '../../utils/copyToClipboard'
-import { formatBalance, formatBalanceAbbreviated, truncateAddress } from '../../utils/formatting'
+import { formatBalanceAbbreviated, truncateAddress } from '../../utils/formatting'
 import { useAddress, useGetExplorerUrl, useWallet } from '../WalletProvider'
 import { useNativeBalance, useNativeCurrency } from '../WalletProvider/evm/utils'
 import { Logo } from '../WalletProvider/SelectButton'
@@ -126,7 +126,7 @@ function ConnectedMenu() {
                   Balance
                 </Text>
                 <Text fontSize={22} fontWeight={500} textAlign="center">
-                  {balance && formatBalance(balance, symbol, 2)}
+                  {balance && formatBalanceAbbreviated(balance, symbol)}
                 </Text>
               </Stack>
             </MenuItemGroup>


### PR DESCRIPTION
### Description
Prevent to long balance and currency string to break into two lines

### Approvals
- [ ] Dev
- [ ] Product

![wallet-menu-before](https://user-images.githubusercontent.com/7050932/227212169-eabc7615-05df-4c4d-a7e2-acd264655837.png)
<img width="318" alt="wallet-menu-after" src="https://user-images.githubusercontent.com/7050932/227212386-981f4e20-6525-4838-8be0-a9906b393429.png">

