### PR TITLE
Change section order on PoolLiquidity view

### DIFF
--- a/centrifuge-app/src/components/Charts/ReserveCashDragChart.tsx
+++ b/centrifuge-app/src/components/Charts/ReserveCashDragChart.tsx
@@ -14,7 +14,7 @@ type ChartData = {
   reserve: number
 }
 
-const ReserveCashDragChart: React.VFC = () => {
+export default function ReserveCashDragChart() {
   const theme = useTheme()
   const { pid: poolId } = useParams<{ pid: string }>()
   const poolStates = useDailyPoolStates(poolId)
@@ -90,10 +90,7 @@ const ReserveCashDragChart: React.VFC = () => {
   )
 }
 
-const CustomLegend: React.VFC<{
-  currency: string
-  data: ChartData
-}> = ({ data, currency }) => {
+function CustomLegend({ data, currency }: { currency: string; data: ChartData }) {
   const theme = useTheme()
 
   return (
@@ -111,5 +108,3 @@ const CustomLegend: React.VFC<{
     </Shelf>
   )
 }
-
-export default ReserveCashDragChart

--- a/centrifuge-app/src/pages/Pool/Liquidity/index.tsx
+++ b/centrifuge-app/src/pages/Pool/Liquidity/index.tsx
@@ -62,14 +62,6 @@ export const PoolDetailLiquidity: React.FC = () => {
       <PageSummary data={pageSummaryData}></PageSummary>
       {!('addresses' in pool) && (
         <>
-          <PageSection title="Reserve vs. cash drag">
-            <Stack height="290px">
-              <React.Suspense fallback={<Spinner />}>
-                <ReserveCashDragChart />
-              </React.Suspense>
-            </Stack>
-          </PageSection>
-
           <LiquidityTransactionsSection
             pool={pool}
             title="Repayments & originations"
@@ -89,6 +81,14 @@ export const PoolDetailLiquidity: React.FC = () => {
           />
 
           <LiquidityEpochSection pool={pool} />
+
+          <PageSection title="Reserve vs. cash drag">
+            <Stack height="290px">
+              <React.Suspense fallback={<Spinner />}>
+                <ReserveCashDragChart />
+              </React.Suspense>
+            </Stack>
+          </PageSection>
         </>
       )}
     </>


### PR DESCRIPTION
### Description
Partly resolves: [1270](https://github.com/centrifuge/apps/issues/1270)

- display ReserveCashDragChart as last section in this view
- refactors ReserveCashDragChart to default function export -> React.VFC is deprecated / no need for additional typing

### Approvals
- [ ] Dev
- [ ] Product
