### PR TITLE
fetch for generic subdoc link

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -25,7 +25,10 @@ It's also recommended to run Prettier automatically in your editor, e.g. using [
 
 ### Onboarding API
 
-1. Add subdocs for new pools and tranches in cloud storage bucket. Format: `centrifuge-onboarding-api-dev/subscription-agreements/<poolId>/<trancheId>.pdf`
+<!-- TODO: make subdocs pool and tranche specific
+1. Add subdocs for new pools and tranches in cloud storage bucket. Format: `centrifuge-onboarding-api-dev/subscription-agreements/<poolId>/<trancheId>.pdf` -->
+
+1. Add a subdoc in cloud storage bucket. Format: `centrifuge-onboarding-api-dev/subscription-agreements/generic_subscription_agreement.pdf`
 2. Add the acceptance page in cloud storage bucket. Format: `centrifuge-onboarding-api-dev/acceptance-page.pdf`
 3. Add the signature page in cloud storage bucket. Format: `centrifuge-onboarding-api-dev/signature-page.pdf`
 4. Onboarding API whitelisting:

--- a/onboarding-api/src/controllers/agreement/getUnsignedAgreement.ts
+++ b/onboarding-api/src/controllers/agreement/getUnsignedAgreement.ts
@@ -15,8 +15,9 @@ export const getUnsignedAgreementController = async (
 ) => {
   try {
     await validateInput(req.query, getUnsignedAgreementInput)
-    const { poolId, trancheId } = req.query
-    const unsignedAgreement = await onboardingBucket.file(`subscription-agreements/${poolId}/${trancheId}.pdf`)
+    // const { poolId, trancheId } = req.query
+    // TODO: make subscription agreements pool and tranche specific
+    const unsignedAgreement = await onboardingBucket.file('subscription-agreements/generic_subscription_agreement.pdf')
 
     const [unsignedAgreementExists] = await unsignedAgreement.exists()
 

--- a/onboarding-api/src/utils/annotateAgreementAndSignAsInvestor.ts
+++ b/onboarding-api/src/utils/annotateAgreementAndSignAsInvestor.ts
@@ -24,7 +24,8 @@ export const annotateAgreementAndSignAsInvestor = async ({
 
   const signedAgreement = await PDFDocument.create()
 
-  const unsignedAgreement = await onboardingBucket.file(`subscription-agreements/${poolId}/${trancheId}.pdf`)
+  // TODO: make subscription agreements pool and tranche specific
+  const unsignedAgreement = await onboardingBucket.file('subscription-agreements/generic_subscription_agreement.pdf')
   const [unsignedAgreementExists] = await unsignedAgreement.exists()
 
   if (!unsignedAgreementExists) {


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

<!-- Describe the goal of this pull request and if possible, insight on the implementation choices. -->

This pull request temporarily configures cent app to fetch for a generic subscription agreement from the Google bucket. Right now, all of the pool/tranche specific documents are identical anyway. Until we are ready to release the app or until we automate the subscription agreement upload step, then I don't think we are ready to have pool/tranche specific subscription agreements. It is just making it unnecessarily painful for testing.

### Approvals

<!-- Depending on the nature of the pull request, remove the roles that are not necessary for this review. Intricate technical changes may require two dev approvals. Reviewers should check the corresponding box after they approve. -->

- [ ] Dev