### PR TITLE
removes status labels

### DIFF
--- a/centrifuge-app/src/components/LoanList.tsx
+++ b/centrifuge-app/src/components/LoanList.tsx
@@ -116,18 +116,18 @@ function Amount({ loan }: { loan: Row }) {
   function getAmount(l: Row) {
     switch (l.status) {
       case 'Closed':
-        return `${formatBalance(l.totalRepaid, pool?.currency.symbol)} repaid`
+        return formatBalance(l.totalRepaid, pool?.currency.symbol)
 
       case 'Active':
         if (l.pricing.interestRate?.gtn(0) && l.totalBorrowed?.isZero()) {
-          return `${formatBalance(current, pool?.currency.symbol)} available`
+          return formatBalance(current, pool?.currency.symbol)
         }
 
         if (l.outstandingDebt.isZero()) {
-          return `${formatBalance(l.totalRepaid, pool?.currency.symbol)} repaid`
+          return formatBalance(l.totalRepaid, pool?.currency.symbol)
         }
 
-        return `${formatBalance(l.outstandingDebt, pool?.currency.symbol)} outstanding`
+        return formatBalance(l.outstandingDebt, pool?.currency.symbol)
 
       default:
         return ''


### PR DESCRIPTION
### Description
In the assets tab, there is an amount and status column and both display the same status of the asset. This ticket removes the duplicate.

issue: https://github.com/centrifuge/apps/issues/1304

### Approvals

- [ ] Product
- [ ] Dev
