### PR TITLE
Refactor MaxReserveForm

### DIFF
--- a/centrifuge-app/src/components/MaxReserveForm.tsx
+++ b/centrifuge-app/src/components/MaxReserveForm.tsx
@@ -11,7 +11,7 @@ type Props = {
   poolId: string
 }
 
-export const MaxReserveForm: React.VFC<Props> = ({ poolId }) => {
+export const MaxReserveForm: React.FC<Props> = ({ poolId }) => {
   const address = useAddress('substrate')
   const isLiquidityAdmin = useLiquidityAdmin(poolId)
   const pool = usePool(poolId)
@@ -24,8 +24,9 @@ export const MaxReserveForm: React.VFC<Props> = ({ poolId }) => {
 
   const form = useFormik<{ maxReserve: number | '' }>({
     initialValues: {
-      maxReserve: '',
+      maxReserve: pool?.reserve.max.toDecimal().toNumber() || '',
     },
+    enableReinitialize: true,
     onSubmit: (values, actions) => {
       if (values.maxReserve) {
         setMaxReserveTx([poolId, CurrencyBalance.fromFloat(values.maxReserve, pool.currency.decimals)])
@@ -50,7 +51,7 @@ export const MaxReserveForm: React.VFC<Props> = ({ poolId }) => {
               {({ field, meta, form }: FieldProps) => (
                 <CurrencyInput
                   {...field}
-                  initialValue={pool?.reserve.max.toDecimal().toNumber()}
+                  initialValue={form.values.maxReserve || undefined}
                   errorMessage={meta.touched ? meta.error : undefined}
                   disabled={isLoading}
                   currency={pool?.currency.symbol}

--- a/centrifuge-app/src/pages/IssuerPool/Liquidity/index.tsx
+++ b/centrifuge-app/src/pages/IssuerPool/Liquidity/index.tsx
@@ -3,16 +3,14 @@ import { useParams } from 'react-router'
 import { LoadBoundary } from '../../../components/LoadBoundary'
 import { MaxReserveForm } from '../../../components/MaxReserveForm'
 import { PageWithSideBar } from '../../../components/PageWithSideBar'
-import { useLiquidityAdmin } from '../../../utils/usePermissions'
 import { PoolDetailLiquidity } from '../../Pool/Liquidity'
 import { IssuerPoolHeader } from '../Header'
 
 export const IssuerPoolLiquidityPage: React.FC = () => {
   const { pid: poolId } = useParams<{ pid: string }>()
-  const isLiquidityAdmin = useLiquidityAdmin(poolId)
 
   return (
-    <PageWithSideBar sidebar={isLiquidityAdmin ? <MaxReserveForm poolId={poolId} /> : true}>
+    <PageWithSideBar sidebar={<MaxReserveForm poolId={poolId} />}>
       <IssuerPoolHeader />
       <LoadBoundary>
         <PoolDetailLiquidity />

--- a/centrifuge-app/src/pages/Pool/Liquidity/index.tsx
+++ b/centrifuge-app/src/pages/Pool/Liquidity/index.tsx
@@ -12,7 +12,6 @@ import { PageWithSideBar } from '../../../components/PageWithSideBar'
 import { Spinner } from '../../../components/Spinner'
 import { Tooltips } from '../../../components/Tooltips'
 import { formatBalance } from '../../../utils/formatting'
-import { useLiquidityAdmin } from '../../../utils/usePermissions'
 import { usePool } from '../../../utils/usePools'
 import { PoolDetailHeader } from '../Header'
 import { PoolDetailSideBar } from '../Overview'
@@ -21,12 +20,12 @@ const ReserveCashDragChart = React.lazy(() => import('../../../components/Charts
 
 export const PoolDetailLiquidityTab: React.FC = () => {
   const { pid: poolId } = useParams<{ pid: string }>()
-  const isLiquidityAdmin = useLiquidityAdmin(poolId)
+
   return (
     <PageWithSideBar
       sidebar={
         <Stack gap={2}>
-          {isLiquidityAdmin ? <MaxReserveForm poolId={poolId} /> : true}
+          <MaxReserveForm poolId={poolId} />
           <PoolDetailSideBar />
         </Stack>
       }


### PR DESCRIPTION
### Description

- use actual pool max reserve as initial value
- enable `formik` to update initial value when pool params are updated -> `enableReinitialize`
- solve ui and code being out of sync: ui displays max reserve value, but `formik` value is `''` (invalid number error thrown -> see screenshot) 
- `MaxReserveForm` checks internally if for 'liquidity admin' right -> removes equal checks higher in the application tree
- React.VFC deprecated -> use React.FC

### Approvals

- [ ] Dev

### Screenshots

<img width="421" alt="Screenshot 2023-05-08 at 11 37 45" src="https://user-images.githubusercontent.com/7050932/236792229-3a264972-5972-4602-aeb1-2675a317f7ac.png">
