### PR TITLE
Fix Asset Lists

### DIFF
--- a/centrifuge-app/.env-config/.env.development
+++ b/centrifuge-app/.env-config/.env.development
@@ -11,6 +11,6 @@ REACT_APP_POOL_CREATION_TYPE=immediate
 REACT_APP_RELAY_WSS_URL=wss://fullnode-relay.development.cntrfg.com
 REACT_APP_SUBQUERY_URL=https://api.subquery.network/sq/centrifuge/pools-development
 REACT_APP_SUBSCAN_URL=
-REACT_APP_TINLAKE_NETWORK=mainnet
+REACT_APP_TINLAKE_NETWORK=goerli
 REACT_APP_INFURA_KEY=bf808e7d3d924fbeb74672d9341d0550
 REACT_APP_WHITELISTED_ACCOUNTS=

--- a/centrifuge-app/.env-config/.env.development
+++ b/centrifuge-app/.env-config/.env.development
@@ -11,6 +11,6 @@ REACT_APP_POOL_CREATION_TYPE=immediate
 REACT_APP_RELAY_WSS_URL=wss://fullnode-relay.development.cntrfg.com
 REACT_APP_SUBQUERY_URL=https://api.subquery.network/sq/centrifuge/pools-development
 REACT_APP_SUBSCAN_URL=
-REACT_APP_TINLAKE_NETWORK=goerli
+REACT_APP_TINLAKE_NETWORK=mainnet
 REACT_APP_INFURA_KEY=bf808e7d3d924fbeb74672d9341d0550
 REACT_APP_WHITELISTED_ACCOUNTS=

--- a/centrifuge-app/src/utils/tinlake/useTinlakePools.ts
+++ b/centrifuge-app/src/utils/tinlake/useTinlakePools.ts
@@ -238,27 +238,37 @@ function getTinlakeLoanStatus(loan: TinlakeLoanData) {
 async function getTinlakeLoans(poolId: string) {
   const query = `
     {
-      loans (first: 1000, where: { pool_in: ["${poolId.toLowerCase()}"]}) {
-        nftId
-        id
-        index
-        financingDate
-        debt
-        pool {
+      pools (where: { id_in: ["${poolId.toLowerCase()}"]}) {
+        loans (first: 1000) {
+          nftId
           id
+          index
+          financingDate
+          debt
+          pool {
+            id
+          }
+          maturityDate
+          interestRatePerSecond
+          borrowsAggregatedAmount
+          repaysAggregatedAmount
+          ceiling
+          closed
+          riskGroup
+          owner
         }
-        maturityDate
-        interestRatePerSecond
-        borrowsAggregatedAmount
-        repaysAggregatedAmount
-        ceiling
-        closed
-        riskGroup
-        owner
       }
     }`
 
-  const { loans } = await request<{ loans: TinlakeLoanData[] }>('https://graph.centrifuge.io/tinlake', query)
+  const data = await request<{ data: any[] }>('https://graph.centrifuge.io/tinlake', query)
+
+  const loans = data.pools.reduce((assets: any[], pool: any) => {
+    if (pool.loans) {
+      assets.push(...pool.loans)
+    }
+    return assets
+  }, [])
+
   return loans
 }
 


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

<!-- Describe the goal of this pull request and if possible, insight on the implementation choices. -->

This pull request fixes the broken asset lists by switching the subgraph query to get loans via pools instead of querying all loans and filtering by pools. For some reason the latter is incredibly slow. Affected pools are NS2 and Branch 3, but this should speed up asset list querying across the board.


