### PR TITLE
fix Error: getLoans normalizedDept

### DIFF
--- a/centrifuge-js/src/modules/pools.ts
+++ b/centrifuge-js/src/modules/pools.ts
@@ -174,6 +174,7 @@ export type ActiveLoanInfoData = {
               | { upToTotalBorrowed: { advanceRate: string } }
               | { upToOutstandingDebt: { advanceRate: string } }
           }
+          normalizedDebt: string
           writeOffPenalty: string
         }
       }
@@ -2456,7 +2457,10 @@ function getOutstandingDebt(
   if (!accrual) return new CurrencyBalance(0, currencyDecimals)
   const accRate = new Rate(hexToBN(accrual.accumulatedRate)).toDecimal()
   const rate = new Rate(hexToBN(accrual.interestRatePerSec)).toDecimal()
-  const normalizedDebt = new CurrencyBalance(hexToBN(loan.normalizedDebt), currencyDecimals).toDecimal()
+  const balance =
+    'internal' in loan.pricing && !loan.normalizedDebt ? loan.pricing.internal.normalizedDebt : loan.normalizedDebt
+
+  const normalizedDebt = new CurrencyBalance(hexToBN(balance), currencyDecimals).toDecimal()
   const secondsSinceUpdated = Date.now() / 1000 - lastUpdated
 
   const debtFromAccRate = normalizedDebt.mul(accRate)


### PR DESCRIPTION
### Description

Error thrown because of missing 'normalizedDebt' for loan data of type ActiveLoanData:
- adds 'normalizedDebt' to ActiveLoanData > pricing > internal (as returned from 'api.query.loans.activeLoans()'
- refactor 'getOutstandingDebt' to get retrieve 'normalizedDebt' from internals

test on pool: 4285291163

### Approvals
- [ ] Dev

### Screenshots

<img width="1657" alt="error-get-loans-normalized-dept" src="https://github.com/centrifuge/apps/assets/7050932/dd0f0ce3-9f52-49b6-a457-75397c85ebf5">

