### PR TITLE
fix: safe auth

### DIFF
--- a/centrifuge-app/src/components/OnboardingAuthProvider.tsx
+++ b/centrifuge-app/src/components/OnboardingAuthProvider.tsx
@@ -237,6 +237,8 @@ Issued At: ${new Date().toISOString()}`
         safeAddress: address,
         messageHash,
         evmChainId,
+        network: 'evmOnSafe',
+        nonce,
       })
     } else {
       throw new Error('Invalid signature')

--- a/centrifuge-app/src/components/OnboardingAuthProvider.tsx
+++ b/centrifuge-app/src/components/OnboardingAuthProvider.tsx
@@ -309,7 +309,7 @@ const isValidSignature = async (provider: any, safeAddress: string, messageHash:
 
 const TX_SERVICE_URLS: Record<string, string> = {
   '1': 'https://safe-transaction-mainnet.safe.global/api',
-  '5': 'https://safe-transaction-goerli.staging.5afe.dev/api',
+  '5': 'https://safe-transaction-goerli.safe.global/api',
 }
 
 const fetchSafeMessage = async (safeMessageHash: string, chainId: number) => {

--- a/onboarding-api/src/controllers/auth/authenticateWallet.ts
+++ b/onboarding-api/src/controllers/auth/authenticateWallet.ts
@@ -1,9 +1,6 @@
-import { InfuraProvider } from '@ethersproject/providers'
 import { isAddress } from '@polkadot/util-crypto'
-import { BigNumber, ethers } from 'ethers'
 import { Request, Response } from 'express'
 import * as jwt from 'jsonwebtoken'
-import fetch from 'node-fetch'
 import { InferType, number, object, string, StringSchema } from 'yup'
 import { SupportedNetworks } from '../../database'
 import { reportHttpError } from '../../utils/httpError'
@@ -48,6 +45,8 @@ const verifySafeInput = object({
       },
     }),
   evmChainId: number().required(),
+  network: string().oneOf(['evmOnSafe']).required() as StringSchema<'evmOnSafe'>,
+  nonce: string().required(),
 })
 
 export const authenticateWalletController = async (
@@ -55,17 +54,9 @@ export const authenticateWalletController = async (
   res: Response
 ) => {
   try {
-    let payload
+    await validateInput(req.body, req.body.network === 'evmOnSafe' ? verifySafeInput : verifyWalletInput)
 
-    if ('safeAddress' in req.body) {
-      await validateInput(req.body, verifySafeInput)
-
-      const provider = new InfuraProvider(req.body.evmChainId, process.env.INFURA_KEY)
-      payload = await verifySafeWallet(provider, req.body.safeAddress, req.body.messageHash, req.body.evmChainId)
-    } else {
-      await validateInput(req.body, verifyWalletInput)
-      payload = await new NetworkSwitch(req.body.network).verifyWallet(req, res)
-    }
+    const payload = await new NetworkSwitch(req.body.network).verifyWallet(req, res)
 
     const token = jwt.sign(payload, process.env.JWT_SECRET, {
       expiresIn: '8h',
@@ -76,63 +67,4 @@ export const authenticateWalletController = async (
     const error = reportHttpError(e)
     return res.status(error.code).send({ error: error.message, e })
   }
-}
-
-const verifySafeWallet = async (provider: any, safeAddress: string, messageHash: string, evmChainId: number) => {
-  try {
-    const MAGIC_VALUE_BYTES = '0x20c13b0b'
-
-    const safeContract = new ethers.Contract(
-      safeAddress,
-      [
-        'function isValidSignature(bytes calldata _data, bytes calldata _signature) public view returns (bytes4)',
-        'function getMessageHash(bytes memory message) public view returns (bytes32)',
-        'function getThreshold() public view returns (uint256)',
-      ],
-      provider
-    )
-
-    const safeMessageHash = await safeContract.getMessageHash(messageHash)
-
-    const safeMessage = await fetchSafeMessage(safeMessageHash, evmChainId)
-
-    if (!safeMessage) {
-      throw new Error('Unable to fetch SafeMessage')
-    }
-
-    const threshold = BigNumber.from(await safeContract.getThreshold()).toNumber()
-
-    if (!threshold || threshold > safeMessage.confirmations.length) {
-      throw new Error('Threshold has not been met')
-    }
-
-    const response = await safeContract.isValidSignature(messageHash, safeMessage?.preparedSignature)
-
-    if (response === MAGIC_VALUE_BYTES) {
-      return {
-        address: safeAddress,
-        chainId: evmChainId,
-        network: 'evm',
-      }
-    }
-
-    throw new Error('Invalid signature')
-  } catch {
-    throw new Error('Something went wrong')
-  }
-}
-
-const TX_SERVICE_URLS: Record<string, string> = {
-  '1': 'https://safe-transaction-mainnet.safe.global/api',
-  '5': 'https://safe-transaction-goerli.staging.5afe.dev/api',
-}
-
-const fetchSafeMessage = async (safeMessageHash: string, chainId: number) => {
-  const TX_SERVICE_URL = TX_SERVICE_URLS[chainId.toString()]
-
-  const response = await fetch(`${TX_SERVICE_URL}/v1/messages/${safeMessageHash}/`, {
-    headers: { 'Content-Type': 'application/json' },
-  })
-
-  return response.json()
 }

--- a/onboarding-api/src/controllers/auth/authenticateWallet.ts
+++ b/onboarding-api/src/controllers/auth/authenticateWallet.ts
@@ -1,6 +1,9 @@
+import { InfuraProvider } from '@ethersproject/providers'
 import { isAddress } from '@polkadot/util-crypto'
+import { BigNumber, ethers } from 'ethers'
 import { Request, Response } from 'express'
 import * as jwt from 'jsonwebtoken'
+import fetch from 'node-fetch'
 import { InferType, number, object, string, StringSchema } from 'yup'
 import { SupportedNetworks } from '../../database'
 import { reportHttpError } from '../../utils/httpError'
@@ -33,13 +36,36 @@ const verifyWalletInput = object({
   chainId: number().required(),
 })
 
+const verifySafeInput = object({
+  messageHash: string().required(),
+  safeAddress: string()
+    .required()
+    .test({
+      name: 'is-address',
+      test(value, ctx) {
+        if (isAddress(value)) return true
+        return ctx.createError({ message: 'Invalid address', path: ctx.path })
+      },
+    }),
+  evmChainId: number().required(),
+})
+
 export const authenticateWalletController = async (
-  req: Request<{}, {}, InferType<typeof verifyWalletInput>>,
+  req: Request<{}, {}, InferType<typeof verifyWalletInput | typeof verifySafeInput>>,
   res: Response
 ) => {
   try {
-    await validateInput(req.body, verifyWalletInput)
-    const payload = await new NetworkSwitch(req.body.network).verifiyWallet(req, res)
+    let payload
+
+    if ('safeAddress' in req.body) {
+      await validateInput(req.body, verifySafeInput)
+
+      const provider = new InfuraProvider(req.body.evmChainId, process.env.INFURA_KEY)
+      payload = await verifySafeWallet(provider, req.body.safeAddress, req.body.messageHash, req.body.evmChainId)
+    } else {
+      await validateInput(req.body, verifyWalletInput)
+      payload = await new NetworkSwitch(req.body.network).verifyWallet(req, res)
+    }
 
     const token = jwt.sign(payload, process.env.JWT_SECRET, {
       expiresIn: '8h',
@@ -50,4 +76,63 @@ export const authenticateWalletController = async (
     const error = reportHttpError(e)
     return res.status(error.code).send({ error: error.message, e })
   }
+}
+
+const verifySafeWallet = async (provider: any, safeAddress: string, messageHash: string, evmChainId: number) => {
+  try {
+    const MAGIC_VALUE_BYTES = '0x20c13b0b'
+
+    const safeContract = new ethers.Contract(
+      safeAddress,
+      [
+        'function isValidSignature(bytes calldata _data, bytes calldata _signature) public view returns (bytes4)',
+        'function getMessageHash(bytes memory message) public view returns (bytes32)',
+        'function getThreshold() public view returns (uint256)',
+      ],
+      provider
+    )
+
+    const safeMessageHash = await safeContract.getMessageHash(messageHash)
+
+    const safeMessage = await fetchSafeMessage(safeMessageHash, evmChainId)
+
+    if (!safeMessage) {
+      throw new Error('Unable to fetch SafeMessage')
+    }
+
+    const threshold = BigNumber.from(await safeContract.getThreshold()).toNumber()
+
+    if (!threshold || threshold > safeMessage.confirmations.length) {
+      throw new Error('Threshold has not been met')
+    }
+
+    const response = await safeContract.isValidSignature(messageHash, safeMessage?.preparedSignature)
+
+    if (response === MAGIC_VALUE_BYTES) {
+      return {
+        address: safeAddress,
+        chainId: evmChainId,
+        network: 'evm',
+      }
+    }
+
+    throw new Error('Invalid signature')
+  } catch {
+    throw new Error('Something went wrong')
+  }
+}
+
+const TX_SERVICE_URLS: Record<string, string> = {
+  '1': 'https://safe-transaction-mainnet.safe.global/api',
+  '5': 'https://safe-transaction-goerli.staging.5afe.dev/api',
+}
+
+const fetchSafeMessage = async (safeMessageHash: string, chainId: number) => {
+  const TX_SERVICE_URL = TX_SERVICE_URLS[chainId.toString()]
+
+  const response = await fetch(`${TX_SERVICE_URL}/v1/messages/${safeMessageHash}/`, {
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+  return response.json()
 }

--- a/onboarding-api/src/utils/networks/evm.ts
+++ b/onboarding-api/src/utils/networks/evm.ts
@@ -124,7 +124,7 @@ export const verifySafeWallet = async (req: Request, res: Response) => {
 
 const TX_SERVICE_URLS: Record<string, string> = {
   '1': 'https://safe-transaction-mainnet.safe.global/api',
-  '5': 'https://safe-transaction-goerli.staging.5afe.dev/api',
+  '5': 'https://safe-transaction-goerli.safe.global/api',
 }
 
 const fetchSafeMessage = async (safeMessageHash: string, chainId: number) => {

--- a/onboarding-api/src/utils/networks/evm.ts
+++ b/onboarding-api/src/utils/networks/evm.ts
@@ -109,10 +109,9 @@ export const verifySafeWallet = async (req: Request, res: Response) => {
   }
 
   const response = await safeContract.isValidSignature(messageHash, safeMessage?.preparedSignature)
+  res.clearCookie(`onboarding-auth-${safeAddress.toLowerCase()}`)
 
   if (response === MAGIC_VALUE_BYTES) {
-    res.clearCookie(`onboarding-auth-${safeAddress.toLowerCase()}`)
-
     return {
       address: safeAddress,
       chainId: evmChainId,

--- a/onboarding-api/src/utils/networks/networkSwitch.ts
+++ b/onboarding-api/src/utils/networks/networkSwitch.ts
@@ -9,18 +9,20 @@ import {
   validateSubstrateRemark,
   verifySubstrateWallet,
 } from './centrifuge'
-import { validateEvmRemark, verifyEvmWallet } from './evm'
+import { validateEvmRemark, verifyEvmWallet, verifySafeWallet } from './evm'
 import { addTinlakeInvestorToMemberList, getTinlakePoolById } from './tinlake'
 
 export class NetworkSwitch {
-  network: SupportedNetworks
-  constructor(network: SupportedNetworks = 'substrate') {
+  network: SupportedNetworks | 'evmOnSafe'
+  constructor(network: SupportedNetworks | 'evmOnSafe' = 'substrate') {
     this.network = network
   }
 
   verifyWallet = (req: Request, res: Response) => {
     if (this.network === 'substrate') {
       return verifySubstrateWallet(req, res)
+    } else if (this.network === 'evmOnSafe') {
+      return verifySafeWallet(req, res)
     } else if (this.network === 'evm' || this.network === 'evmOnSubstrate') {
       return verifyEvmWallet(req, res)
     }

--- a/onboarding-api/src/utils/networks/networkSwitch.ts
+++ b/onboarding-api/src/utils/networks/networkSwitch.ts
@@ -18,7 +18,7 @@ export class NetworkSwitch {
     this.network = network
   }
 
-  verifiyWallet = (req: Request, res: Response) => {
+  verifyWallet = (req: Request, res: Response) => {
     if (this.network === 'substrate') {
       return verifySubstrateWallet(req, res)
     } else if (this.network === 'evm' || this.network === 'evmOnSubstrate') {


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

<!-- Describe the goal of this pull request and if possible, insight on the implementation choices. -->

This pull request fixes an issue when authenticating on the `/onboarding` page with a Safe wallet. Since Safe wallets are smart contracts, they [can not generate ECDSA signatures](https://ethereum.stackexchange.com/questions/122458/web3-eth-personal-sign-with-walletconnect-and-gnosis-safe/122469#122469). Therefore, Safe uses [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) for message signing and validating signatures. I mostly followed this [guide](https://docs.safe.global/safe-smart-account/signatures/eip-1271#verifying-a-signature) from Safe's documentation in order to implement the signature validation for when a user is using Safe. However, since we generate jwt's on the server side, I needed to do the check on both the frontend/backend.

<!-- This will link the pull request to a Github issue. Remove if there is no corresponding Github issue. -->

Closes #1649 

### Approvals

<!-- Depending on the nature of the pull request, remove the roles that are not necessary for this review. Intricate technical changes may require two dev approvals. Reviewers should check the corresponding box after they approve. -->

- [x] Dev
- [x] Product