### PR TITLE
Fix typo on Gfunctions action

### DIFF
--- a/.github/actions/deploy-gfunction/action.yml
+++ b/.github/actions/deploy-gfunction/action.yml
@@ -126,7 +126,7 @@ runs:
         service_account_email: ${{ inputs.service_account }}
         max_instances: ${{ contains(steps.prepare.outputs.function_name, 'production') && '200' || '10' }}
         https_trigger_security_level: "secure_always"
-        memory_mb: ${{ intputs.memory }}
+        memory_mb: ${{ inputs.memory }}
 
     - name: Print Gcloud functions URL
       shell: sh


### PR DESCRIPTION
Small typo on the inputs for Gfunctions is making the main branch fail. Somehow the checks didn't show this