### PR TITLE
Use evm inputs for issuers

### DIFF
--- a/centrifuge-app/src/pages/IssuerPool/Access/AssetOriginators.tsx
+++ b/centrifuge-app/src/pages/IssuerPool/Access/AssetOriginators.tsx
@@ -1,6 +1,7 @@
 import {
   addressToHex,
   computeTrancheId,
+  evmToSubstrateAddress,
   getCurrencyLocation,
   isSameAddress,
   PoolMetadata,
@@ -8,6 +9,7 @@ import {
   WithdrawAddress,
 } from '@centrifuge/centrifuge-js'
 import {
+  useCentEvmChainId,
   useCentrifuge,
   useCentrifugeApi,
   useCentrifugeConsts,
@@ -118,6 +120,7 @@ function AOForm({
   poolId: string
 }) {
   const [isEditing, setIsEditing] = React.useState(false)
+  const chainId = useCentEvmChainId()
   const [account] = useSuitableAccounts({ poolId, actingAddress: [ao.address] }).filter((a) => a.proxies?.length === 2)
   const identity = useIdentity(ao.address)
   const api = useCentrifugeApi()
@@ -311,8 +314,8 @@ function AOForm({
       }
       execute(
         [
-          addedWithdraw.map((w) => getKeyForReceiver(api, w)),
-          removedWithdraw.map((w) => getKeyForReceiver(api, w)),
+          addedWithdraw.filter((w) => Object.keys(w).length !== 0).map((w) => getKeyForReceiver(api, w)),
+          removedWithdraw.filter((w) => Object.keys(w).length !== 0).map((w) => getKeyForReceiver(api, w)),
           null,
           addedPermissions,
           addedDelegates,
@@ -438,7 +441,9 @@ function AOForm({
                       <AddAddressInput
                         existingAddresses={[...form.values.delegates, ao.address]}
                         onAdd={(address) => {
-                          fldArr.push(addressToHex(address))
+                          fldArr.push(
+                            isEvmAddress(address) ? evmToSubstrateAddress(address, chainId ?? 0) : addressToHex(address)
+                          )
                         }}
                       />
                     )}

--- a/centrifuge-app/src/pages/IssuerPool/Access/MultisigForm.tsx
+++ b/centrifuge-app/src/pages/IssuerPool/Access/MultisigForm.tsx
@@ -1,16 +1,20 @@
-import { addressToHex } from '@centrifuge/centrifuge-js'
+import { evmToSubstrateAddress } from '@centrifuge/centrifuge-js'
+import { useCentEvmChainId } from '@centrifuge/centrifuge-react'
 import { Button, IconMinusCircle, Stack, Text } from '@centrifuge/fabric'
 import { FieldArray, useFormikContext } from 'formik'
 import * as React from 'react'
 import { DataTable } from '../../../components/DataTable'
 import { Identity } from '../../../components/Identity'
+import { isEvmAddress } from '../../../utils/address'
 import { AddAddressInput } from '../Configuration/AddAddressInput'
 import { ChangeThreshold } from './ChangeTreshold'
 import type { PoolManagersInput } from './PoolManagers'
 
 type Row = { address: string; index: number }
 type Props = { isEditing?: boolean; isLoading?: boolean; canRemoveFirst?: boolean }
+
 export function MultisigForm({ isEditing = true, canRemoveFirst = true, isLoading }: Props) {
+  const chainId = useCentEvmChainId()
   const form = useFormikContext<PoolManagersInput>()
   const { adminMultisig } = form.values
   const rows = React.useMemo(
@@ -66,7 +70,7 @@ export function MultisigForm({ isEditing = true, canRemoveFirst = true, isLoadin
                   if (adminMultisig.signers.length === 1) {
                     form.setFieldValue('adminMultisig.threshold', 2, false)
                   }
-                  fldArr.push(addressToHex(address))
+                  fldArr.push(isEvmAddress(address) ? evmToSubstrateAddress(address, chainId ?? 0) : address)
                 }}
               />
             )}

--- a/centrifuge-app/src/pages/IssuerPool/Configuration/AddAddressInput.tsx
+++ b/centrifuge-app/src/pages/IssuerPool/Configuration/AddAddressInput.tsx
@@ -1,6 +1,6 @@
-import { isSameAddress } from '@centrifuge/centrifuge-js'
+import { addressToHex, isSameAddress } from '@centrifuge/centrifuge-js'
 import { useCentrifugeUtils } from '@centrifuge/centrifuge-react'
-import { Button, Grid, SearchInput, Shelf, Text } from '@centrifuge/fabric'
+import { AddressInput, Button, Grid, Shelf, Text } from '@centrifuge/fabric'
 import Identicon from '@polkadot/react-identicon'
 import { useState } from 'react'
 import { truncate } from '../../../utils/web3'
@@ -15,26 +15,40 @@ export function AddAddressInput({
   const [address, setAddress] = useState('')
 
   const utils = useCentrifugeUtils()
-  let truncated
+  let truncated: string | undefined
   try {
     truncated = truncate(utils.formatAddress(address))
   } catch (e) {
-    //
+    truncated = undefined
   }
 
   const exists = !!truncated && existingAddresses.some((addr) => isSameAddress(addr, address))
 
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const newAddress = e.target.value
+    setAddress(newAddress)
+  }
+
+  function handleBlur(e: React.FocusEvent<HTMLInputElement>) {
+    const address = e.target.value
+    if (truncated) {
+      onAdd(addressToHex(address))
+      setAddress('')
+    }
+  }
+
   return (
     <Grid columns={2} equalColumns gap={4} alignItems="center">
-      <SearchInput
-        name="search"
+      <AddressInput
+        clearIcon
         placeholder="Search to add address..."
         value={address}
-        onChange={(e) => setAddress(e.target.value)}
+        onChange={handleChange}
+        onBlur={handleBlur}
       />
       {address &&
         (truncated ? (
-          <Shelf gap={2}>
+          <Shelf gap={2} alignItems="center">
             <Shelf style={{ pointerEvents: 'none' }} gap="4px">
               <Identicon value={address} size={16} theme="polkadot" />
               <Text variant="label2" color="textPrimary">
@@ -44,7 +58,7 @@ export function AddAddressInput({
             <Button
               variant="secondary"
               onClick={() => {
-                onAdd(address)
+                onAdd(addressToHex(address))
                 setAddress('')
               }}
               small

--- a/centrifuge-app/src/pages/IssuerPool/Investors/InvestorStatus.tsx
+++ b/centrifuge-app/src/pages/IssuerPool/Investors/InvestorStatus.tsx
@@ -7,6 +7,7 @@ import {
   useWallet,
 } from '@centrifuge/centrifuge-react'
 import {
+  AddressInput,
   Button,
   Grid,
   IconAlertCircle,
@@ -14,7 +15,6 @@ import {
   IconInfoFailed,
   IconMinus,
   IconPlus,
-  SearchInput,
   Select,
   Shelf,
   Stack,
@@ -95,6 +95,10 @@ export function InvestorStatus() {
     setPendingTrancheId(trancheId)
   }
 
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setAddress(e.target.value)
+  }
+
   return (
     <PageSection
       title="Investor status"
@@ -102,12 +106,7 @@ export function InvestorStatus() {
     >
       <Stack gap={2}>
         <Grid columns={2} gap={2} alignItems="center">
-          <SearchInput
-            name="investorStatus"
-            value={address}
-            onChange={(e) => setAddress(e.target.value)}
-            placeholder="Enter address..."
-          />
+          <AddressInput label="" placeholder="Add an address" onChange={handleChange} value={address} />
           <Select
             value={chain}
             options={[

--- a/centrifuge-js/src/utils/index.ts
+++ b/centrifuge-js/src/utils/index.ts
@@ -137,7 +137,7 @@ export function computeMultisig(multisig: Multisig): ComputedMultisig {
 }
 
 export function evmToSubstrateAddress(address: string, chainId: number) {
-  if (!chainId) return
+  if (!chainId) throw new Error('chainId is required')
 
   // Bytes EVM\0 as suffix
   const suffix = '45564d00'

--- a/centrifuge-js/src/utils/index.ts
+++ b/centrifuge-js/src/utils/index.ts
@@ -137,6 +137,8 @@ export function computeMultisig(multisig: Multisig): ComputedMultisig {
 }
 
 export function evmToSubstrateAddress(address: string, chainId: number) {
+  if (!chainId) return
+
   // Bytes EVM\0 as suffix
   const suffix = '45564d00'
   const chainHex = Number(chainId).toString(16).padStart(16, '0')

--- a/fabric/src/components/TextInput/index.tsx
+++ b/fabric/src/components/TextInput/index.tsx
@@ -252,7 +252,10 @@ export function TextAreaInput({
 }
 
 export type AddressInputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value'> &
-  Omit<InputUnitProps, 'inputElement'>
+  Omit<InputUnitProps, 'inputElement'> & {
+    value?: string
+    clearIcon?: boolean
+  }
 
 export function AddressInput({
   id,
@@ -262,6 +265,8 @@ export function AddressInput({
   errorMessage,
   onBlur,
   onChange,
+  value = '',
+  clearIcon,
   ...inputProps
 }: AddressInputProps) {
   const defaultId = React.useId()
@@ -269,18 +274,19 @@ export function AddressInput({
 
   const [network, setNetwork] = React.useState<'ethereum' | 'centrifuge' | 'loading' | null>(null)
 
-  function handleChange(e: React.FocusEvent<HTMLInputElement>) {
-    const address = e.target.value
-    if (isEvmAddress(address) && address.length > 3) {
+  React.useEffect(() => {
+    if (isEvmAddress(value) && value.length > 3) {
       setNetwork('ethereum')
-    } else if (isSubstrateAddress(address) && address.length > 3) {
+    } else if (isSubstrateAddress(value) && value.length > 3) {
       setNetwork('centrifuge')
-    } else if (address !== '') {
+    } else if (value !== '') {
       setNetwork('loading')
     } else {
       setNetwork(null)
     }
+  }, [value])
 
+  function handleChange(e: React.FocusEvent<HTMLInputElement>) {
     if (onChange) {
       onChange(e)
     }
@@ -288,7 +294,7 @@ export function AddressInput({
 
   function handleBlur(e: React.FocusEvent<HTMLInputElement>) {
     const address = e.target.value
-    if (!(isSubstrateAddress(address) || isEvmAddress(address))) {
+    if (!(isSubstrateAddress(address) || isEvmAddress(address)) || clearIcon) {
       setNetwork(null)
     }
 
@@ -296,6 +302,7 @@ export function AddressInput({
       onBlur(e)
     }
   }
+
   return (
     <InputUnit
       label={label}
@@ -308,6 +315,7 @@ export function AddressInput({
           type="text"
           onChange={handleChange}
           onBlur={handleBlur}
+          value={value}
           action={
             network && (
               <Shelf


### PR DESCRIPTION
Use the address input that we have for CFG transfers, that supports both EVM addresses and Centrifuge addresses

#2221 

### Approvals

- [ ] Dev
- [x ] Dev
- [ ] Designer
- [ x] Product


### Impact

Pool managers on Create pool page
Investor input for Centrifuge Chain on Investors tab
AO wallets on Access tab
Receiving address on Fees tab
