### PR TITLE
Pool creation improvements

### DIFF
--- a/centrifuge-app/src/pages/IssuerCreatePool/AdminMultisig.tsx
+++ b/centrifuge-app/src/pages/IssuerCreatePool/AdminMultisig.tsx
@@ -14,7 +14,7 @@ export function AdminMultisigSection() {
 
   return (
     <PageSection
-      title="Pool Managers"
+      title="Pool managers"
       headerRight={
         adminMultisigEnabled ? (
           <Button variant="secondary" small onClick={() => form.setFieldValue('adminMultisigEnabled', false)}>

--- a/centrifuge-app/src/pages/IssuerCreatePool/IssuerInput.tsx
+++ b/centrifuge-app/src/pages/IssuerCreatePool/IssuerInput.tsx
@@ -3,6 +3,7 @@ import { Field, FieldProps } from 'formik'
 import * as React from 'react'
 import { FieldWithErrorMessage } from '../../components/FieldWithErrorMessage'
 import { Tooltips } from '../../components/Tooltips'
+import { isTestEnv } from '../../config'
 import { CustomDetails } from './CustomDetails'
 import { validate } from './validate'
 
@@ -10,11 +11,7 @@ type Props = {
   waitingForStoredIssuer?: boolean
 }
 
-const IS_TESTNETS =
-  import.meta.env.REACT_APP_COLLATOR_WSS_URL.includes('development') ||
-  import.meta.env.REACT_APP_COLLATOR_WSS_URL.includes('demo')
-
-const createLabel = (label: string) => `${label}${IS_TESTNETS ? '' : '*'}`
+const createLabel = (label: string) => `${label}${isTestEnv ? '' : '*'}`
 
 export const IssuerInput: React.FC<Props> = ({ waitingForStoredIssuer = false }) => {
   return (
@@ -32,7 +29,7 @@ export const IssuerInput: React.FC<Props> = ({ waitingForStoredIssuer = false })
       </Box>
       <Box gridColumn={['span 1', 'span 2']}>
         <FieldWithErrorMessage
-          validate={!IS_TESTNETS && validate.issuerRepName}
+          validate={!isTestEnv && validate.issuerRepName}
           name="issuerRepName"
           as={TextInput}
           label={
@@ -49,7 +46,7 @@ export const IssuerInput: React.FC<Props> = ({ waitingForStoredIssuer = false })
       </Box>
       <Box gridColumn={['span 1', 'span 2']}>
         <FieldWithErrorMessage
-          validate={!IS_TESTNETS && validate.issuerDescription}
+          validate={!isTestEnv && validate.issuerDescription}
           name="issuerDescription"
           as={TextAreaInput}
           label={
@@ -85,7 +82,7 @@ export const IssuerInput: React.FC<Props> = ({ waitingForStoredIssuer = false })
       <Box gridColumn={['span 1', 'span 2']}>
         <Text>Links</Text>
       </Box>
-      <Field name="executiveSummary" validate={!IS_TESTNETS && validate.executiveSummary}>
+      <Field name="executiveSummary" validate={!isTestEnv && validate.executiveSummary}>
         {({ field, meta, form }: FieldProps) => (
           <FileUpload
             file={field.value}
@@ -105,7 +102,7 @@ export const IssuerInput: React.FC<Props> = ({ waitingForStoredIssuer = false })
         as={TextInput}
         label={createLabel('Website')}
         placeholder="https://..."
-        validate={!IS_TESTNETS && validate.website}
+        validate={!isTestEnv && validate.website}
       />
       <FieldWithErrorMessage
         name="forum"
@@ -119,7 +116,7 @@ export const IssuerInput: React.FC<Props> = ({ waitingForStoredIssuer = false })
         as={TextInput}
         label={createLabel('Email')}
         placeholder=""
-        validate={!IS_TESTNETS && validate.email}
+        validate={!isTestEnv && validate.email}
       />
 
       <Box gridColumn={['span 1', 'span 2']}>

--- a/centrifuge-app/src/pages/IssuerCreatePool/IssuerInput.tsx
+++ b/centrifuge-app/src/pages/IssuerCreatePool/IssuerInput.tsx
@@ -10,6 +10,12 @@ type Props = {
   waitingForStoredIssuer?: boolean
 }
 
+const IS_TESTNETS =
+  import.meta.env.REACT_APP_COLLATOR_WSS_URL.includes('development') ||
+  import.meta.env.REACT_APP_COLLATOR_WSS_URL.includes('demo')
+
+const createLabel = (label: string) => `${label}${IS_TESTNETS ? '' : '*'}`
+
 export const IssuerInput: React.FC<Props> = ({ waitingForStoredIssuer = false }) => {
   return (
     <Grid columns={[1, 2]} equalColumns gap={2} rowGap={3}>
@@ -26,10 +32,16 @@ export const IssuerInput: React.FC<Props> = ({ waitingForStoredIssuer = false })
       </Box>
       <Box gridColumn={['span 1', 'span 2']}>
         <FieldWithErrorMessage
-          validate={validate.issuerRepName}
+          validate={!IS_TESTNETS && validate.issuerRepName}
           name="issuerRepName"
           as={TextInput}
-          label={<Tooltips type="issuerRepName" label="Legal name of issuer representative*" variant="secondary" />}
+          label={
+            <Tooltips
+              type="issuerRepName"
+              label={createLabel('Legal name of issuer representative')}
+              variant="secondary"
+            />
+          }
           placeholder="Full name..."
           maxLength={100}
           disabled={waitingForStoredIssuer}
@@ -37,10 +49,16 @@ export const IssuerInput: React.FC<Props> = ({ waitingForStoredIssuer = false })
       </Box>
       <Box gridColumn={['span 1', 'span 2']}>
         <FieldWithErrorMessage
-          validate={validate.issuerDescription}
+          validate={!IS_TESTNETS && validate.issuerDescription}
           name="issuerDescription"
           as={TextAreaInput}
-          label={<Tooltips type="poolDescription" variant="secondary" label="Description (minimum 100 characters)*" />}
+          label={
+            <Tooltips
+              type="poolDescription"
+              variant="secondary"
+              label={createLabel('Description (minimum 100 characters)')}
+            />
+          }
           placeholder="Description..."
           maxLength={1000}
           disabled={waitingForStoredIssuer}
@@ -67,7 +85,7 @@ export const IssuerInput: React.FC<Props> = ({ waitingForStoredIssuer = false })
       <Box gridColumn={['span 1', 'span 2']}>
         <Text>Links</Text>
       </Box>
-      <Field name="executiveSummary" validate={validate.executiveSummary}>
+      <Field name="executiveSummary" validate={!IS_TESTNETS && validate.executiveSummary}>
         {({ field, meta, form }: FieldProps) => (
           <FileUpload
             file={field.value}
@@ -76,7 +94,7 @@ export const IssuerInput: React.FC<Props> = ({ waitingForStoredIssuer = false })
               form.setFieldValue('executiveSummary', file)
             }}
             accept="application/pdf"
-            label="Executive summary PDF*"
+            label={createLabel('Executive summary PDF')}
             placeholder="Choose file"
             errorMessage={meta.touched && meta.error ? meta.error : undefined}
           />
@@ -85,9 +103,9 @@ export const IssuerInput: React.FC<Props> = ({ waitingForStoredIssuer = false })
       <FieldWithErrorMessage
         name="website"
         as={TextInput}
-        label="Website*"
+        label={createLabel('Website')}
         placeholder="https://..."
-        validate={validate.website}
+        validate={!IS_TESTNETS && validate.website}
       />
       <FieldWithErrorMessage
         name="forum"
@@ -96,7 +114,13 @@ export const IssuerInput: React.FC<Props> = ({ waitingForStoredIssuer = false })
         placeholder="https://..."
         validate={validate.forum}
       />
-      <FieldWithErrorMessage name="email" as={TextInput} label="Email*" placeholder="" validate={validate.email} />
+      <FieldWithErrorMessage
+        name="email"
+        as={TextInput}
+        label={createLabel('Email')}
+        placeholder=""
+        validate={!IS_TESTNETS && validate.email}
+      />
 
       <Box gridColumn={['span 1', 'span 2']}>
         <CustomDetails />

--- a/centrifuge-app/src/pages/IssuerCreatePool/index.tsx
+++ b/centrifuge-app/src/pages/IssuerCreatePool/index.tsx
@@ -64,6 +64,10 @@ const ASSET_CLASSES = Object.keys(config.assetClasses).map((key) => ({
   value: key,
 }))
 
+const IS_TESTNETS =
+  import.meta.env.REACT_APP_COLLATOR_WSS_URL.includes('development') ||
+  import.meta.env.REACT_APP_COLLATOR_WSS_URL.includes('demo')
+
 export default function IssuerCreatePoolPage() {
   return (
     <LayoutBase>
@@ -85,12 +89,12 @@ export interface WriteOffGroupInput {
   penaltyInterest: number | ''
 }
 
-export const createEmptyTranche = (junior?: boolean): Tranche => ({
-  tokenName: '',
+export const createEmptyTranche = (trancheName: string): Tranche => ({
+  tokenName: trancheName,
   symbolName: '',
-  interestRate: junior ? '' : 0,
-  minRiskBuffer: junior ? '' : 0,
-  minInvestment: 0,
+  interestRate: trancheName === 'Junior' ? '' : 0,
+  minRiskBuffer: trancheName === 'Junior' ? '' : 0,
+  minInvestment: 1000,
 })
 
 export type CreatePoolValues = Omit<
@@ -122,8 +126,8 @@ const initialValues: CreatePoolValues = {
   poolName: '',
   assetClass: 'Private credit',
   subAssetClass: '',
-  currency: '',
-  maxReserve: '',
+  currency: IS_TESTNETS ? 'USDC' : 'Native USDC',
+  maxReserve: 1000000,
   epochHours: 23, // in hours
   epochMinutes: 50, // in minutes
   listed: !import.meta.env.REACT_APP_DEFAULT_UNLIST_POOLS,
@@ -143,7 +147,7 @@ const initialValues: CreatePoolValues = {
   reportAuthorAvatar: null,
   reportUrl: '',
 
-  tranches: [createEmptyTranche(true)],
+  tranches: [createEmptyTranche('Junior')],
   adminMultisig: {
     signers: [],
     threshold: 1,
@@ -644,18 +648,20 @@ function CreatePoolForm() {
               </Box>
               <Box gridColumn="span 2">
                 <Field name="currency" validate={validate.currency}>
-                  {({ field, form, meta }: FieldProps) => (
-                    <Select
-                      name="currency"
-                      label={<Tooltips type="currency" label="Currency*" variant="secondary" />}
-                      onChange={(event) => form.setFieldValue('currency', event.target.value)}
-                      onBlur={field.onBlur}
-                      errorMessage={meta.touched && meta.error ? meta.error : undefined}
-                      value={field.value}
-                      options={currencies?.map((c) => ({ value: c.symbol, label: c.name })) ?? []}
-                      placeholder="Select..."
-                    />
-                  )}
+                  {({ field, form, meta }: FieldProps) => {
+                    return (
+                      <Select
+                        name="currency"
+                        label={<Tooltips type="currency" label="Currency*" variant="secondary" />}
+                        onChange={(event) => form.setFieldValue('currency', event.target.value)}
+                        onBlur={field.onBlur}
+                        errorMessage={meta.touched && meta.error ? meta.error : undefined}
+                        value={field.value}
+                        options={currencies?.map((c) => ({ value: c.symbol, label: c.name })) ?? []}
+                        placeholder="Select..."
+                      />
+                    )
+                  }}
                 </Field>
               </Box>
               <Box gridColumn="span 2">

--- a/centrifuge-js/src/modules/pools.ts
+++ b/centrifuge-js/src/modules/pools.ts
@@ -989,7 +989,7 @@ export function getPoolsModule(inst: Centrifuge) {
           }
         : 'Residual',
       metadata: {
-        tokenName: `${metadata.poolName} ${metadata.tranches[i].tokenName}`,
+        tokenName: metadata.tranches[i].tokenName,
         tokenSymbol: metadata.tranches[i].symbolName,
       },
     }))


### PR DESCRIPTION
- Default currency to native USDC on testnets, localUSDC on production
- Default initial max reserve to 1M
- Make legal name of the issuer representative and description non required on testnets
- Make executive summary PDF, website, email all non required on testnets
- Allow empty Token name in Tranches. Disable token name input for 1 tranche (will just be the pool name). If a 2nd tranche is added, default to Senior | Junior. If a 3rd tranche is added, default to Senior | Mezzanine | Junior.
- Don't allow adding more than 3 tranches
-  Default min investment to 1,000.
- Pool Managers => Pool managers

#2231 

- [x ] Dev
- [ ] Dev
- [ ] Designer
- [x ] Product
