### PR TITLE
Links for wallets

### DIFF
--- a/centrifuge-app/src/components/SupportedBrowserBanner.tsx
+++ b/centrifuge-app/src/components/SupportedBrowserBanner.tsx
@@ -1,11 +1,11 @@
-import { useWallet } from '@centrifuge/centrifuge-react'
 import { Banner, Text } from '@centrifuge/fabric'
 import * as React from 'react'
+import { getSupportedBrowser } from '../utils/getSupportedBrowser'
 
 export const SupportedBrowserBanner = () => {
-  const wallet = useWallet()
   const storageKey = 'browser-banner-seen'
-  const isSupported = navigator.userAgent.indexOf('Chrome') > -1
+  const browser = getSupportedBrowser()
+  const isSupported = browser !== 'unknown'
   const [isOpen, setIsOpen] = React.useState(false)
 
   React.useEffect(() => {
@@ -17,7 +17,7 @@ export const SupportedBrowserBanner = () => {
     setIsOpen(false)
   }
 
-  if (isSupported || !wallet.connectedNetwork) {
+  if (isSupported) {
     return null
   }
 

--- a/centrifuge-app/src/utils/getSupportedBrowser.tsx
+++ b/centrifuge-app/src/utils/getSupportedBrowser.tsx
@@ -1,0 +1,11 @@
+// Function to detect the browser
+export const getSupportedBrowser = () => {
+  const userAgent = navigator.userAgent
+  if (userAgent.includes('Chrome') && !userAgent.includes('Edg')) {
+    return 'chrome'
+  } else if (userAgent.includes('Firefox')) {
+    return 'firefox'
+  } else {
+    return 'unknown'
+  }
+}

--- a/centrifuge-react/src/components/WalletProvider/WalletDialog.tsx
+++ b/centrifuge-react/src/components/WalletProvider/WalletDialog.tsx
@@ -1,3 +1,4 @@
+import { getSupportedBrowser } from '@centrifuge/centrifuge-app/src/utils/getSupportedBrowser'
 import {
   Button,
   Card,
@@ -38,6 +39,24 @@ const title = {
   networks: 'Connect wallet',
   wallets: 'Connect wallet',
   accounts: 'Choose account',
+}
+
+const walletsList: { [key: string]: string } = {
+  talisman: 'talisman-wallet-extension',
+  'subwallet-js': 'subwallet',
+  'polkadot-js': 'polkadot-js-extension',
+  'fearless-wallet': 'fearless-wallet',
+  metamask: 'ether-metamask',
+}
+
+const getAdjustedInstallUrl = (wallet: { extensionName: string; installUrl: string }): string => {
+  const browser = getSupportedBrowser()
+  const { extensionName, installUrl } = wallet
+  if (browser === 'firefox') {
+    return `https://addons.mozilla.org/en-US/firefox/addon/${walletsList[extensionName]}/`
+  } else {
+    return installUrl
+  }
 }
 
 export function WalletDialog({ evmChains: allEvmChains, showAdvancedAccounts, showTestNets, showFinoa }: Props) {
@@ -198,8 +217,8 @@ export function WalletDialog({ evmChains: allEvmChains, showAdvancedAccounts, sh
               }
             >
               <Grid minColumnWidth={120} mt={3} gap={1}>
-                {shownWallets.map((wallet) =>
-                  wallet.installed ? (
+                {shownWallets.map((wallet) => {
+                  return wallet.installed ? (
                     <SelectButton
                       key={wallet.title}
                       logo={<Logo icon={wallet.logo.src} />}
@@ -221,7 +240,7 @@ export function WalletDialog({ evmChains: allEvmChains, showAdvancedAccounts, sh
                   ) : (
                     <SelectAnchor
                       key={wallet.title}
-                      href={wallet.installUrl}
+                      href={getAdjustedInstallUrl(wallet)}
                       logo={<Logo icon={wallet.logo.src} />}
                       iconRight={<IconDownload size="iconSmall" color="textPrimary" />}
                       muted={isMuted(selectedNetwork!)}
@@ -229,7 +248,7 @@ export function WalletDialog({ evmChains: allEvmChains, showAdvancedAccounts, sh
                       {wallet.title}
                     </SelectAnchor>
                   )
-                )}
+                })}
               </Grid>
             </SelectionStep>
           </>

--- a/centrifuge-react/src/components/WalletProvider/WalletDialog.tsx
+++ b/centrifuge-react/src/components/WalletProvider/WalletDialog.tsx
@@ -51,9 +51,9 @@ const walletsList: { [key: string]: string } = {
 
 const getAdjustedInstallUrl = (wallet: { extensionName: string; installUrl: string }): string => {
   const browser = getSupportedBrowser()
-  const { extensionName, installUrl } = wallet
+  const { installUrl } = wallet
   if (browser === 'firefox') {
-    return `https://addons.mozilla.org/en-US/firefox/addon/${walletsList[extensionName]}/`
+    return `https://addons.mozilla.org/en-US/firefox/addon/${walletsList['extensionName' in wallet ? wallet.extensionName : 'metamask']}/`
   } else {
     return installUrl
   }

--- a/centrifuge-react/src/components/WalletProvider/WalletDialog.tsx
+++ b/centrifuge-react/src/components/WalletProvider/WalletDialog.tsx
@@ -35,6 +35,11 @@ type Props = {
   showFinoa?: boolean
 }
 
+type WalletFn = {
+  installUrl: string
+  extensionName?: string
+}
+
 const title = {
   networks: 'Connect wallet',
   wallets: 'Connect wallet',
@@ -49,11 +54,12 @@ const walletsList: { [key: string]: string } = {
   metamask: 'ether-metamask',
 }
 
-const getAdjustedInstallUrl = (wallet: { extensionName: string; installUrl: string }): string => {
+const getAdjustedInstallUrl = (wallet: WalletFn): string => {
   const browser = getSupportedBrowser()
   const { installUrl } = wallet
   if (browser === 'firefox') {
-    return `https://addons.mozilla.org/en-US/firefox/addon/${walletsList['extensionName' in wallet ? wallet.extensionName : 'metamask']}/`
+    const extensionName = wallet.extensionName ?? 'metamask'
+    return `https://addons.mozilla.org/en-US/firefox/addon/${walletsList[extensionName]}/`
   } else {
     return installUrl
   }

--- a/centrifuge-react/src/components/WalletProvider/evm/connectors.ts
+++ b/centrifuge-react/src/components/WalletProvider/evm/connectors.ts
@@ -26,6 +26,7 @@ export type EvmConnectorMeta = {
   id: string
   title: string
   installUrl: string
+  extensionName: string
   logo: {
     src: string
     alt: string
@@ -128,6 +129,7 @@ export function getEvmConnectors(
       get shown() {
         return !isMobile() || this.installed
       },
+      extensionName: 'metamask'
     },
     walletConnect && {
       id: 'walletconnect',

--- a/centrifuge-react/src/components/WalletProvider/evm/connectors.ts
+++ b/centrifuge-react/src/components/WalletProvider/evm/connectors.ts
@@ -26,7 +26,6 @@ export type EvmConnectorMeta = {
   id: string
   title: string
   installUrl: string
-  extensionName: string
   logo: {
     src: string
     alt: string
@@ -129,7 +128,6 @@ export function getEvmConnectors(
       get shown() {
         return !isMobile() || this.installed
       },
-      extensionName: 'metamask'
     },
     walletConnect && {
       id: 'walletconnect',


### PR DESCRIPTION
- Show non-support banner regardless if user wallet is connected. Do not show the banner if browser is chrome/firefox
- Links to firefox store shall be different than the url for chrome store. Unfortunately '@subwallet/wallet-connect/types' only returns walletUrl for chrome only, some hard code links was required to make it work on firefox.

#1838 

- [ x ] Dev
- [ ] Dev
- [ ] Designer
- [ ] Product
