### PR TITLE
Add fixes to assets fields table

### DIFF
--- a/centrifuge-app/src/pages/Loan/MetricsTable.tsx
+++ b/centrifuge-app/src/pages/Loan/MetricsTable.tsx
@@ -1,33 +1,62 @@
+import { AnchorTextLink } from '@centrifuge/centrifuge-app/src/components/TextLink'
 import { Box, Grid, Text } from '@centrifuge/fabric'
 
+type Metric = {
+  label: string
+  value: string
+}
+
 type Props = {
-  metrics: { label: string; value: string }[]
+  metrics: Metric[]
 }
 
 export function MetricsTable({ metrics }: Props) {
   return (
     <Box borderStyle="solid" borderWidth="1px" borderColor="borderPrimary">
-      {metrics.map(({ label, value }, index) => (
-        <Grid
-          borderBottomStyle={index === metrics.length - 1 ? 'none' : 'solid'}
-          borderBottomWidth={index === metrics.length - 1 ? '0' : '1px'}
-          borderBottomColor={index === metrics.length - 1 ? 'none' : 'borderPrimary'}
-          height={32}
-          key={index}
-          px={1}
-          gridTemplateColumns="1fr 1fr"
-          width="100%"
-          alignItems="center"
-          gap={2}
-        >
-          <Text variant="body3" textOverflow="ellipsis" whiteSpace="nowrap">
-            {label}
-          </Text>
-          <Text variant="body3" textOverflow="ellipsis" whiteSpace="nowrap">
-            {value}
-          </Text>
-        </Grid>
-      ))}
+      {metrics.map(({ label, value }, index) => {
+        const multirow = value && value.length > 20
+        const asLink = value && /^(https?:\/\/[^\s]+)$/.test(value)
+
+        const defaultStyle: React.CSSProperties = {
+          whiteSpace: 'nowrap',
+          textOverflow: 'ellipsis',
+          overflow: 'hidden',
+        }
+
+        const multiRowStyle: React.CSSProperties = multirow
+          ? {
+              whiteSpace: 'normal',
+              wordWrap: 'break-word',
+              overflow: 'visible',
+              lineHeight: '1.2',
+              padding: '4px 0',
+            }
+          : {}
+
+        const combinedStyle: React.CSSProperties = { ...defaultStyle, ...multiRowStyle }
+
+        return (
+          <Grid
+            borderBottomStyle={index === metrics.length - 1 ? 'none' : 'solid'}
+            borderBottomWidth={index === metrics.length - 1 ? '0' : '1px'}
+            borderBottomColor={index === metrics.length - 1 ? 'none' : 'borderPrimary'}
+            key={index}
+            px={1}
+            gridTemplateColumns="1fr 1fr"
+            width="100%"
+            alignItems="center"
+            gap={2}
+            height={multirow ? 'auto' : 32}
+          >
+            <Text variant="body3" textOverflow="ellipsis" whiteSpace="nowrap">
+              {label}
+            </Text>
+            <Text variant="body3" style={combinedStyle}>
+              {asLink ? <AnchorTextLink href={value}>{value}</AnchorTextLink> : value}
+            </Text>
+          </Grid>
+        )
+      })}
     </Box>
   )
 }

--- a/centrifuge-app/src/pages/Loan/index.tsx
+++ b/centrifuge-app/src/pages/Loan/index.tsx
@@ -250,7 +250,10 @@ function Loan() {
                               const attribute = templateData.attributes?.[key]!
                               const value = publicData[key]
                               const formatted = value ? formatNftAttribute(value, attribute) : '-'
-                              return { label: attribute.label, value: formatted }
+                              return {
+                                label: attribute.label,
+                                value: formatted,
+                              }
                             })}
                         />
                       </Stack>


### PR DESCRIPTION
- Fund Short Description should be fully shown, taking up multiple rows
- Fund Link should automatically become <a> with target="_blank"

#2263 

- [ x ] Dev
- [ ] Dev
- [ ] Designer
- [ x ] Product

<img width="412" alt="Screenshot 2024-07-04 at 10 48 09 AM" src="https://github.com/centrifuge/apps/assets/51223655/5b8ab1bd-cd53-43b6-8004-89712ade812e">
