### PR TITLE
Fix layout on assets detail page

### DIFF
--- a/centrifuge-app/src/components/Charts/AssetPerformanceChart.tsx
+++ b/centrifuge-app/src/components/Charts/AssetPerformanceChart.tsx
@@ -139,13 +139,6 @@ function AssetPerformanceChart({ pool, poolId, loanId }: Props) {
 
   const isChartEmpty = React.useMemo(() => !data.length || assetSnapshots?.length < 1, [data, assetSnapshots])
 
-  const aggregatedData = data.reduce((acc, cur, index) => {
-    if (index % 2 === 0) {
-      acc.push(cur)
-    }
-    return acc
-  }, [])
-
   if (!assetSnapshots) return <Spinner style={{ margin: 'auto', height: 350 }} />
 
   return (
@@ -198,9 +191,9 @@ function AssetPerformanceChart({ pool, poolId, loanId }: Props) {
         )}
 
         <Shelf gap={4} width="100%" color="textSecondary">
-          {aggregatedData?.length ? (
+          {data?.length ? (
             <ResponsiveContainer width="100%" height={200} minHeight={200} maxHeight={200}>
-              <LineChart data={aggregatedData} margin={{ left: -36 }}>
+              <LineChart data={data} margin={{ left: -36 }}>
                 <defs>
                   <linearGradient id="colorPoolValue" x1="0" y1="0" x2="0" y2="1">
                     <stop offset="5%" stopColor={chartColor} stopOpacity={0.4} />

--- a/centrifuge-app/src/components/Charts/AssetPerformanceChart.tsx
+++ b/centrifuge-app/src/components/Charts/AssetPerformanceChart.tsx
@@ -137,8 +137,9 @@ function AssetPerformanceChart({ pool, poolId, loanId }: Props) {
     return [min, max]
   }, [data])
 
+  const isChartEmpty = React.useMemo(() =>  !data.length || assetSnapshots?.length < 1, [data, assetSnapshots])
+
   if (!assetSnapshots) return <Spinner style={{ margin: 'auto' }} />
-  if (assetSnapshots?.length < 1) return null
 
   return (
     <Card p={3}>
@@ -149,7 +150,7 @@ function AssetPerformanceChart({ pool, poolId, loanId }: Props) {
               ? 'Asset performance'
               : 'Cash balance'}
           </Text>
-          <AnchorButton
+          {!isChartEmpty && <AnchorButton
             href={dataUrl}
             download={`asset-${loanId}-timeseries.csv`}
             variant="secondary"
@@ -157,8 +158,10 @@ function AssetPerformanceChart({ pool, poolId, loanId }: Props) {
             small
           >
             Download
-          </AnchorButton>
+          </AnchorButton>}
         </Shelf>
+
+        {isChartEmpty && <Text variant="label1">No data yet</Text>}
 
         {!(assetSnapshots && assetSnapshots[0]?.currentPrice?.toString() === '0') && (
           <Stack>

--- a/centrifuge-app/src/components/Charts/AssetPerformanceChart.tsx
+++ b/centrifuge-app/src/components/Charts/AssetPerformanceChart.tsx
@@ -137,12 +137,19 @@ function AssetPerformanceChart({ pool, poolId, loanId }: Props) {
     return [min, max]
   }, [data])
 
-  const isChartEmpty = React.useMemo(() =>  !data.length || assetSnapshots?.length < 1, [data, assetSnapshots])
+  const isChartEmpty = React.useMemo(() => !data.length || assetSnapshots?.length < 1, [data, assetSnapshots])
 
-  if (!assetSnapshots) return <Spinner style={{ margin: 'auto' }} />
+  const aggregatedData = data.reduce((acc, cur, index) => {
+    if (index % 2 === 0) {
+      acc.push(cur)
+    }
+    return acc
+  }, [])
+
+  if (!assetSnapshots) return <Spinner style={{ margin: 'auto', height: 350 }} />
 
   return (
-    <Card p={3}>
+    <Card p={3} height={350}>
       <Stack gap={2}>
         <Shelf justifyContent="space-between">
           <Text fontSize="18px" fontWeight="500">
@@ -150,15 +157,17 @@ function AssetPerformanceChart({ pool, poolId, loanId }: Props) {
               ? 'Asset performance'
               : 'Cash balance'}
           </Text>
-          {!isChartEmpty && <AnchorButton
-            href={dataUrl}
-            download={`asset-${loanId}-timeseries.csv`}
-            variant="secondary"
-            icon={IconDownload}
-            small
-          >
-            Download
-          </AnchorButton>}
+          {!isChartEmpty && (
+            <AnchorButton
+              href={dataUrl}
+              download={`asset-${loanId}-timeseries.csv`}
+              variant="secondary"
+              icon={IconDownload}
+              small
+            >
+              Download
+            </AnchorButton>
+          )}
         </Shelf>
 
         {isChartEmpty && <Text variant="label1">No data yet</Text>}
@@ -189,9 +198,9 @@ function AssetPerformanceChart({ pool, poolId, loanId }: Props) {
         )}
 
         <Shelf gap={4} width="100%" color="textSecondary">
-          {data?.length ? (
-            <ResponsiveContainer width="100%" height="100%" minHeight="200px">
-              <LineChart data={data} margin={{ left: -36 }}>
+          {aggregatedData?.length ? (
+            <ResponsiveContainer width="100%" height={200} minHeight={200} maxHeight={200}>
+              <LineChart data={aggregatedData} margin={{ left: -36 }}>
                 <defs>
                   <linearGradient id="colorPoolValue" x1="0" y1="0" x2="0" y2="1">
                     <stop offset="5%" stopColor={chartColor} stopOpacity={0.4} />
@@ -205,9 +214,11 @@ function AssetPerformanceChart({ pool, poolId, loanId }: Props) {
                   tickFormatter={(tick: number) => {
                     return new Date(tick).toLocaleString('en-US', { day: 'numeric', month: 'short' })
                   }}
-                  style={{ fontSize: '10px', fill: theme.colors.textSecondary, letterSpacing: '-0.5px' }}
+                  style={{ fontSize: 8, fill: theme.colors.textSecondary, letterSpacing: '-0.7px' }}
                   dy={4}
                   interval={10}
+                  angle={-40}
+                  textAnchor="end"
                 />
                 <YAxis
                   stroke="none"

--- a/centrifuge-app/src/components/Charts/PoolPerformanceChart.tsx
+++ b/centrifuge-app/src/components/Charts/PoolPerformanceChart.tsx
@@ -139,7 +139,7 @@ function PoolPerformanceChart() {
 
       <Shelf gap={4} width="100%" color="textSecondary">
         {chartData?.length ? (
-          <ResponsiveContainer width="100%" height="100%" minHeight="200px">
+          <ResponsiveContainer width="100%" height={200} minHeight={200} maxHeight={200}>
             <ComposedChart data={chartData} margin={{ left: -36 }}>
               <defs>
                 <linearGradient id="colorPoolValue" x1="0" y1="0" x2="0" y2="1">

--- a/centrifuge-app/src/components/LiquidityTransactionsSection.tsx
+++ b/centrifuge-app/src/components/LiquidityTransactionsSection.tsx
@@ -11,6 +11,7 @@ import { StackedBarChart, StackedBarChartProps } from './Charts/StackedBarChart'
 import { getRangeNumber } from './Charts/utils'
 import { PageSection } from './PageSection'
 import { TooltipsProps } from './Tooltips'
+import { LoadBoundary } from './LoadBoundary'
 
 const rangeFilters = [
   { value: '30d', label: '30 days' },
@@ -127,7 +128,10 @@ export default function LiquidityTransactionsSection({
       : []
   }, [chartData, dataColors, tooltips, pool.currency.symbol])
 
-  return chartData?.length ? (
+  if(!chartData?.length) return null
+
+  return(
+  <LoadBoundary>
     <PageSection
       title={title}
       titleAddition={
@@ -179,5 +183,5 @@ export default function LiquidityTransactionsSection({
         <StackedBarChart data={chartData} names={dataNames} colors={dataColors} currency={pool.currency.symbol} />
       )}
     </PageSection>
-  ) : null
+    </LoadBoundary>)
 }

--- a/centrifuge-app/src/components/PoolOverview/PoolPerfomance.tsx
+++ b/centrifuge-app/src/components/PoolOverview/PoolPerfomance.tsx
@@ -1,9 +1,11 @@
 import { Card, Stack, Text } from '@centrifuge/fabric'
+import React from 'react'
 import PoolPerformanceChart from '../Charts/PoolPerformanceChart'
+import { Spinner } from '../Spinner'
 
-export const PoolPerformance = () => {
-  return (
-    <Card p={3}>
+export const PoolPerformance = () => (
+  <React.Suspense fallback={<Spinner style={{ height: 400 }} />}>
+    <Card p={3} height={400}>
       <Stack gap={2}>
         <Text fontSize="18px" fontWeight="500">
           Pool performance
@@ -11,5 +13,5 @@ export const PoolPerformance = () => {
         <PoolPerformanceChart />
       </Stack>
     </Card>
-  )
-}
+  </React.Suspense>
+)

--- a/centrifuge-app/src/components/Portfolio/CardPortfolioValue.tsx
+++ b/centrifuge-app/src/components/Portfolio/CardPortfolioValue.tsx
@@ -63,6 +63,7 @@ export function CardPortfolioValue({
         p={2}
         style={{
           boxShadow: `0px 3px 2px -2px ${colors.borderPrimary}`,
+          height: 450,
         }}
         background={colors.backgroundPage}
       >
@@ -116,14 +117,8 @@ export function CardPortfolioValue({
                 {transactions?.investorTransactions.length ? (
                   <PortfolioValue rangeValue={range.value} address={centAddress} />
                 ) : (
-                  <Box
-                    width="100%"
-                    height="100%"
-                    display="flex"
-                    alignItems="center"
-                    justifyContent="center"
-                  >
-                    <Text>No data available</Text> 
+                  <Box width="100%" height="100%" display="flex" alignItems="center" justifyContent="center">
+                    <Text>No data available</Text>
                   </Box>
                 )}
               </LoadBoundary>

--- a/centrifuge-app/src/components/Portfolio/CardPortfolioValue.tsx
+++ b/centrifuge-app/src/components/Portfolio/CardPortfolioValue.tsx
@@ -113,7 +113,19 @@ export function CardPortfolioValue({
 
             <Box width="100%" height="300px">
               <LoadBoundary>
-                <PortfolioValue rangeValue={range.value} address={centAddress} />
+                {transactions?.investorTransactions.length ? (
+                  <PortfolioValue rangeValue={range.value} address={centAddress} />
+                ) : (
+                  <Box
+                    width="100%"
+                    height="100%"
+                    display="flex"
+                    alignItems="center"
+                    justifyContent="center"
+                  >
+                    <Text>No data available</Text> 
+                  </Box>
+                )}
               </LoadBoundary>
             </Box>
           </>

--- a/centrifuge-app/src/components/Portfolio/PortfolioValue.tsx
+++ b/centrifuge-app/src/components/Portfolio/PortfolioValue.tsx
@@ -44,7 +44,7 @@ export function PortfolioValue({ rangeValue, address }: { rangeValue: string; ad
   }
 
   return (
-    <ResponsiveContainer>
+    <ResponsiveContainer height={300} maxHeight={300} minHeight={300}>
       <AreaChart
         margin={{
           top: 35,

--- a/centrifuge-app/src/pages/Pool/Liquidity/index.tsx
+++ b/centrifuge-app/src/pages/Pool/Liquidity/index.tsx
@@ -63,7 +63,6 @@ export function PoolDetailLiquidity() {
       </PageSummary>
       {!('addresses' in pool) && (
         <>
-          <LoadBoundary>
             <LiquidityTransactionsSection
               pool={pool}
               title="Originations & repayments"
@@ -72,9 +71,7 @@ export function PoolDetailLiquidity() {
               dataColors={[colors.grayScale[500], colors.blueScale[500]]}
               tooltips={['repayment', 'origination']}
             />
-          </LoadBoundary>
 
-          <LoadBoundary>
             <LiquidityTransactionsSection
               pool={pool}
               title="Investments & redemptions"
@@ -83,7 +80,6 @@ export function PoolDetailLiquidity() {
               dataColors={[colors.statusOk, colors.statusCritical]}
               tooltips={['investment', 'redemption']}
             />
-          </LoadBoundary>
           {/* 
           <PageSection title="Cash drag">
             <Stack height="290px">

--- a/centrifuge-app/src/pages/Pool/Overview/index.tsx
+++ b/centrifuge-app/src/pages/Pool/Overview/index.tsx
@@ -133,9 +133,7 @@ export function PoolDetailOverview() {
   return (
     <FullHeightLayoutSection bg={theme.colors.backgroundSecondary} pt={2} pb={4}>
       <Grid height="fit-content" gridTemplateColumns={['1fr', '1fr', '66fr minmax(275px, 33fr)']} gap={[2, 2, 3]}>
-        <React.Suspense fallback={<Spinner />}>
-          <PoolPerformance />
-        </React.Suspense>
+        <PoolPerformance />
         <React.Suspense fallback={<Spinner />}>
           <KeyMetrics
             assetType={metadata?.pool?.asset}


### PR DESCRIPTION
- Asset detail page:  Add < no data available > if data is empty to avoid layout emptiness/switching **(picture 1)**
- Liquidity page: Prevent layout switching by reorganizing rendering of component **(picture 2)**
- Prime page: Add box around graph layout to maintain dimensions. **(picture 3)**

#2223 

- [ x ] Dev

**Picture 1**
<img width="1076" alt="Screenshot 2024-07-11 at 11 24 02 AM" src="https://github.com/centrifuge/apps/assets/51223655/60e68b7a-e925-4c62-bd4e-f94e285a20e1">

**Picture 2**

https://github.com/centrifuge/apps/assets/51223655/e0334def-5766-4eac-ba7f-43e4d07faafc

**Picture 3**
![Uploading Screenshot 2024-07-11 at 1.45.46 PM.png…]()

