### PR TITLE
Fix Total value locked (TVL) box to cover only half width of page

### DIFF
--- a/centrifuge-app/src/pages/Pools.tsx
+++ b/centrifuge-app/src/pages/Pools.tsx
@@ -1,4 +1,4 @@
-import { Stack, Text } from '@centrifuge/fabric'
+import { Shelf, Stack, Text } from '@centrifuge/fabric'
 import * as React from 'react'
 import { CardTotalValueLocked } from '../components/CardTotalValueLocked'
 import { LayoutBase } from '../components/LayoutBase'
@@ -27,9 +27,11 @@ export default function PoolsPage() {
               }`}
             </Text>
           </Stack>
-          <LoadBoundary>
-            <CardTotalValueLocked />
-          </LoadBoundary>
+          <Shelf width="50%">
+            <LoadBoundary>
+              <CardTotalValueLocked />
+            </LoadBoundary>
+          </Shelf>
         </Stack>
         <PoolList />
       </LayoutSection>


### PR DESCRIPTION
Fix Total value locked (TVL) box to cover only half width of page

#2291 

- [ ] Dev

<img width="1092" alt="Screenshot 2024-07-22 at 10 35 50 AM" src="https://github.com/user-attachments/assets/e76fa550-3485-43e9-84a0-7723890f21a7">
