### PR TITLE
Add padding to pools list

### DIFF
--- a/centrifuge-app/src/pages/Pools.tsx
+++ b/centrifuge-app/src/pages/Pools.tsx
@@ -31,8 +31,8 @@ export default function PoolsPage() {
             <CardTotalValueLocked />
           </LoadBoundary>
         </Stack>
+        <PoolList />
       </LayoutSection>
-      <PoolList />
     </LayoutBase>
   )
 }


### PR DESCRIPTION
Padding y=5 was removed when the unused component was removed. Add back the padding.

#2290 

- [ ] Dev

