### PR TITLE
Fix links style

### DIFF
--- a/centrifuge-app/src/components/Menu/PageLink.tsx
+++ b/centrifuge-app/src/components/Menu/PageLink.tsx
@@ -10,6 +10,8 @@ const Root = styled(Text)<{ isActive?: boolean; stacked?: boolean }>`
   ${primaryButton}
   grid-template-columns: ${({ stacked, theme }) => (stacked ? '1fr' : `${theme.sizes.iconSmall}px 1fr`)};
   color: ${({ isActive }) => (isActive ? 'blue' : 'black')}; /* Example styling */
+  font-size: 14px;
+  font-weight: 500;
 `
 
 type PageLinkProps = LinkProps & {


### PR DESCRIPTION
When upgrading react-router, the new `<Link /> `have default style of 16px over the 14px we were using before in our menu. Causing a discrepancy between the components with `<Link />` and the components with `<Text />`

#2007 

- [ ] Dev


<img width="211" alt="Screenshot 2024-07-24 at 1 26 10 PM" src="https://github.com/user-attachments/assets/a7f0c9fd-e14e-41a2-8b41-9771537a70ea">


<img width="428" alt="Screenshot 2024-07-24 at 8 00 16 AM" src="https://github.com/user-attachments/assets/8c9e4a1b-bdc1-4d6e-83fa-1fddda5fef40">

