### PR TITLE
Fixes asset list component

### DIFF
--- a/centrifuge-app/src/components/LoanList.tsx
+++ b/centrifuge-app/src/components/LoanList.tsx
@@ -9,7 +9,6 @@ import {
   Stack,
   Text,
   TextWithPlaceholder,
-  Thumbnail,
   usePagination,
 } from '@centrifuge/fabric'
 import get from 'lodash/get'
@@ -308,7 +307,6 @@ export function AssetName({ loan }: { loan: Pick<Row, 'id' | 'poolId' | 'asset' 
 
   return (
     <Shelf gap="1" alignItems="center" justifyContent="center" style={{ whiteSpace: 'nowrap', maxWidth: '100%' }}>
-      <Thumbnail type="asset" label={loan.id} />
       <TextWithPlaceholder
         isLoading={isLoading}
         width={12}

--- a/centrifuge-app/src/components/LoanList.tsx
+++ b/centrifuge-app/src/components/LoanList.tsx
@@ -104,7 +104,7 @@ export function LoanList({ loans }: Props) {
       header: <SortableTableHeader label="Asset" />,
       cell: (l: Row) => <AssetName loan={l} />,
       sortKey: 'idSortKey',
-      width: 'minmax(150px, 1fr)',
+      width: 'minmax(300px, 1fr)',
     },
     isTinlakePool && {
       align: 'left',
@@ -153,6 +153,7 @@ export function LoanList({ loans }: Props) {
         />
       ),
       cell: (l: Row) => <LoanLabel loan={l} />,
+      width: '100px',
     },
     {
       header: '',
@@ -228,11 +229,11 @@ export function LoanList({ loans }: Props) {
             <DataTable
               data={rows}
               columns={columns}
-              pinnedData={pinnedData}
-              defaultSortOrder="desc"
+              defaultSortKey="maturityDate"
               onRowClicked={(row) => `${basePath}/${poolId}/assets/${row.id}`}
               pageSize={20}
               page={pagination.page}
+              pinnedData={pinnedData}
             />
           </Box>
         </LoadBoundary>
@@ -344,7 +345,7 @@ function Amount({ loan }: { loan: Row }) {
         return formatBalance(pool.reserve.total, pool?.currency.symbol)
 
       default:
-        return ''
+        return `0 ${pool?.currency.symbol}`
     }
   }
 


### PR DESCRIPTION
- remove the numbers associated with the asset (1,2,3,4).
- Sort the list by descending maturity date.
- Set amount to 0 if the asset is empty
- Make the asset name column wider so we can see the full asset name, or full text of the asset. We will need this for DYF

#2314 


- [ ] Dev