### PR TITLE
Date timezone causing error - convert to UTC

### DIFF
--- a/centrifuge-app/src/utils/date.ts
+++ b/centrifuge-app/src/utils/date.ts
@@ -3,6 +3,7 @@ export function formatDate(timestamp: number | string | Date, options?: Intl.Dat
     year: 'numeric',
     month: 'short',
     day: 'numeric',
+    timeZone: 'UTC',
     ...options,
   })
 }


### PR DESCRIPTION
Settlement date & maturity date format date function causing error when transforming dates from timestamp.

#2325 

- [ ] Dev
