### PR TITLE
Reduce calls to subquery

### DIFF
--- a/centrifuge-app/src/components/PoolList.tsx
+++ b/centrifuge-app/src/components/PoolList.tsx
@@ -9,7 +9,7 @@ import { TinlakePool } from '../utils/tinlake/useTinlakePools'
 import { useIsAboveBreakpoint } from '../utils/useIsAboveBreakpoint'
 import { useListedPools } from '../utils/useListedPools'
 import { useMetadataMulti } from '../utils/useMetadata'
-import { MetaData, PoolCard, PoolCardProps, Tranche } from './PoolCard'
+import { MetaData, PoolCard, PoolCardProps } from './PoolCard'
 import { PoolStatusKey } from './PoolCard/PoolStatus'
 import { filterPools } from './PoolFilter/utils'
 
@@ -154,7 +154,7 @@ export function poolsToPoolCardProps(
           ? 'Open for investments'
           : ('Closed' as PoolStatusKey),
       iconUri: metaData?.pool?.icon?.uri ? cent.metadata.parseMetadataUrl(metaData?.pool?.icon?.uri) : undefined,
-      tranches: pool.tranches as Tranche[],
+      tranches: pool.tranches,
       metaData: metaData as MetaData,
     }
   })

--- a/centrifuge-app/src/components/PoolOverview/TrancheTokenCards.tsx
+++ b/centrifuge-app/src/components/PoolOverview/TrancheTokenCards.tsx
@@ -1,4 +1,3 @@
-import { Perquintill } from '@centrifuge/centrifuge-js'
 import { Box, Shelf, Stack, Text } from '@centrifuge/fabric'
 import { InvestButton, Token } from '../../pages/Pool/Overview'
 import { daysBetween } from '../../utils/date'
@@ -74,7 +73,7 @@ const TrancheTokenCard = ({
     if (poolId === '1655476167') return formatPercentage(15)
     if (isTinlakePool && trancheText === 'senior') return formatPercentage(trancheToken.apy)
     if (daysSinceCreation < 30 || !trancheToken.yield30DaysAnnualized) return 'N/A'
-    return formatPercentage(new Perquintill(trancheToken.yield30DaysAnnualized))
+    return formatPercentage(trancheToken.yield30DaysAnnualized)
   }
 
   return (

--- a/centrifuge-app/src/utils/tinlake/useTinlakePools.ts
+++ b/centrifuge-app/src/utils/tinlake/useTinlakePools.ts
@@ -198,8 +198,7 @@ export function useTinlakeLoans(poolId: string) {
 export type TinlakePool = Omit<Pool, 'metadata' | 'loanCollectionId' | 'tranches'> & {
   metadata: PoolMetadata
   tinlakeMetadata: PoolMetadataDetails
-  tranches: (Omit<Pool['tranches'][0], 'poolMetadata' | 'yield30DaysAnnualized'> & {
-    yield30DaysAnnualized?: string | null
+  tranches: (Omit<Pool['tranches'][0], 'poolMetadata'> & {
     poolMetadata: PoolMetadata
     pendingInvestments: CurrencyBalance
     pendingRedemptions: TokenBalance

--- a/centrifuge-js/src/modules/pools.ts
+++ b/centrifuge-js/src/modules/pools.ts
@@ -2161,7 +2161,9 @@ export function getPoolsModule(inst: Centrifuge) {
                     poolId,
                     poolMetadata: (metadata ?? undefined) as string | undefined,
                     interestRatePerSec,
-                    yield30DaysAnnualized: yield30DaysTrancheId?.[`${poolId}-${trancheId}`] ? new Perquintill( yield30DaysTrancheId[`${poolId}-${trancheId}`]!) : null,
+                    yield30DaysAnnualized: yield30DaysTrancheId?.[`${poolId}-${trancheId}`]
+                      ? new Perquintill(yield30DaysTrancheId[`${poolId}-${trancheId}`]!)
+                      : null,
                     minRiskBuffer,
                     currentRiskBuffer,
                     capacity: CurrencyBalance.fromFloat(capacity, currency.decimals),

--- a/centrifuge-js/src/modules/pools.ts
+++ b/centrifuge-js/src/modules/pools.ts
@@ -317,7 +317,7 @@ export type Tranche = {
   minRiskBuffer: Perquintill | null
   currentRiskBuffer: Perquintill
   interestRatePerSec: Rate | null
-  yield30DaysAnnualized?: string | null
+  yield30DaysAnnualized: Perquintill | null
   lastUpdatedInterest: string
   ratio: Perquintill
 }
@@ -2054,13 +2054,6 @@ export function getPoolsModule(inst: Centrifuge) {
           })
           .flat()
 
-        const $yield30DaysAnnualized = combineLatest(
-          keys.map((key) => {
-            const poolIdTrancheId = `${key[0]}-${key[1].toLowerCase()}`
-            return getLatestTrancheSnapshot(poolIdTrancheId).pipe(map((snapshot) => snapshot?.trancheSnapshots.nodes))
-          })
-        ) as Observable<{ yield30DaysAnnualized: string | null; trancheId: string }[][]>
-
         const trancheIdToIndex: Record<string, number> = {}
         keys.forEach(([, tid], i) => {
           trancheIdToIndex[tid] = i
@@ -2080,11 +2073,11 @@ export function getPoolsModule(inst: Centrifuge) {
 
         const $block = inst.getBlocks().pipe(take(1))
 
-        return combineLatest([$issuance, $block, $prices, $navs, $yield30DaysAnnualized]).pipe(
-          map(([rawIssuances, { block }, rawPrices, rawNavs, [rawYield30DaysAnnualized]]) => {
+        return combineLatest([$issuance, $block, $prices, $navs, getLatestTrancheSnapshots()]).pipe(
+          map(([rawIssuances, { block }, rawPrices, rawNavs, rawYield30DaysAnnualized]) => {
             const blockNumber = block.header.number.toNumber()
 
-            const yield30DaysAnnualizedByPoolIdTrancheId = rawYield30DaysAnnualized?.reduce(
+            const yield30DaysTrancheId = rawYield30DaysAnnualized?.trancheSnapshots.nodes.reduce(
               (acc, { yield30DaysAnnualized, trancheId }) => {
                 acc[trancheId] = yield30DaysAnnualized
                 return acc
@@ -2168,7 +2161,7 @@ export function getPoolsModule(inst: Centrifuge) {
                     poolId,
                     poolMetadata: (metadata ?? undefined) as string | undefined,
                     interestRatePerSec,
-                    yield30DaysAnnualized: yield30DaysAnnualizedByPoolIdTrancheId?.[`${poolId}-${trancheId}`],
+                    yield30DaysAnnualized: yield30DaysTrancheId?.[`${poolId}-${trancheId}`] ? new Perquintill( yield30DaysTrancheId[`${poolId}-${trancheId}`]!) : null,
                     minRiskBuffer,
                     currentRiskBuffer,
                     capacity: CurrencyBalance.fromFloat(capacity, currency.decimals),
@@ -2301,21 +2294,18 @@ export function getPoolsModule(inst: Centrifuge) {
     )
   }
 
-  function getLatestTrancheSnapshot(poolIdTrancheId: string) {
+  function getLatestTrancheSnapshots() {
     return inst.getSubqueryObservable<{
       trancheSnapshots: { nodes: { yield30DaysAnnualized: string | null; trancheId: string }[] }
     }>(
-      `query ($poolIdTrancheId: String!) {
-        trancheSnapshots(filter: { trancheId: { equalTo: $poolIdTrancheId } }, last: 1) {
+      `{
+        trancheSnapshots(distinct: TRANCHE_ID, orderBy: TIMESTAMP_DESC) {
           nodes {
             trancheId
             yield30DaysAnnualized
           }
         }
-      }`,
-      {
-        poolIdTrancheId,
-      }
+      }`
     )
   }
   function getPoolSnapshotsWithCursor(poolId: string, endCursor: string | null, from?: Date, to?: Date) {


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

Getting the latest tranche snapshots for all tranches for all pools was the cause of the large amount of calls to subquery. There was a call for each tranche, and it was done more than once for some reason. With over a hundred pools/tranches on demo that was a lot. Now getting the yields in `getPools` is done with one call for all pools/tranches.

[#2432](https://github.com/centrifuge/apps/issues/2432)

### Approvals

<!-- Depending on the nature of the pull request, remove the roles that are not necessary for this review. Intricate technical changes may require two dev approvals. Reviewers should check the corresponding box after they approve. -->

- [ ] Dev

### Screenshots

<!-- Supporting screenshots, gifs, or videos to give reviewers an idea of how the pull request will affect the presentation of the app. -->

### Impact

<!-- Describe what parts of the app were affected so that reviewers can direct their focus. -->
