### PR TITLE
Fix bug on the disabled button

### DIFF
--- a/centrifuge-app/src/pages/Portfolio/CFGTokenMigration.tsx
+++ b/centrifuge-app/src/pages/Portfolio/CFGTokenMigration.tsx
@@ -58,6 +58,7 @@ export default function CFGTokenMigration() {
 
   const allowance = useCheckAllowance(address).data
   const isPendingAllowance = allowance && !allowance?.isZero()
+  const isAllowanceSameAsBalance = allowance?.toNumber() === balance?.toNumber()
 
   useEffect(() => {
     async function getGasPrice() {
@@ -71,9 +72,9 @@ export default function CFGTokenMigration() {
 
   useEffect(() => {
     if (isPendingAllowance) {
-      setStep(allowance?.toNumber() === balance?.toNumber() ? 2 : 0)
+      setStep(isAllowanceSameAsBalance ? 2 : 0)
     }
-  }, [isPendingAllowance])
+  }, [isPendingAllowance, isAllowanceSameAsBalance])
 
   const { execute: executeDeposit, isLoading: isDepositing } = useEvmTransaction(
     `Migrate WCFG for CFG`,
@@ -102,7 +103,7 @@ export default function CFGTokenMigration() {
   )
 
   const migrate = () => {
-    if (isPendingAllowance) {
+    if (isAllowanceSameAsBalance) {
       executeDeposit([() => {}, CurrencyBalance.fromFloat(balance || 0, 18), cfgConfig.iou])
     } else {
       setStep(1)
@@ -221,7 +222,7 @@ export default function CFGTokenMigration() {
                   loading={isApproving || isDepositing}
                   disabled={balance?.isZero()}
                 >
-                  {isPendingAllowance ? 'Migrate WCFG' : 'Approve WCFG and migrate'}
+                  {isAllowanceSameAsBalance ? 'Migrate WCFG' : 'Approve WCFG and migrate'}
                 </Button>
                 <MigrationSupportLink />
                 <Box mt={2} justifyContent="center" display="flex">

--- a/centrifuge-app/src/pages/Portfolio/CFGTokenMigrationCent.tsx
+++ b/centrifuge-app/src/pages/Portfolio/CFGTokenMigrationCent.tsx
@@ -118,6 +118,7 @@ export default function CFGTokenMigrationCent() {
   )
 
   const migrate = async () => {
+    if (isMigrationBlocked || !isAddressValid) return
     executeMigration([])
   }
 
@@ -281,7 +282,12 @@ export default function CFGTokenMigrationCent() {
                     lost tokens.
                   </Text>
                 </Grid>
-                <Button small style={{ width: '100%' }} onClick={() => setStep(1)} disabled={!isAddressValid}>
+                <Button
+                  small
+                  style={{ width: '100%' }}
+                  onClick={() => setStep(1)}
+                  disabled={!isAddressValid || isMigrationBlocked}
+                >
                   Migrate
                 </Button>
               </>

--- a/centrifuge-app/src/pages/Portfolio/useTokenBalance.tsx
+++ b/centrifuge-app/src/pages/Portfolio/useTokenBalance.tsx
@@ -4,6 +4,9 @@ import { useQuery } from 'react-query'
 import { isTestEnv } from '../../../src/config'
 import { currencies } from '../../../src/utils/tinlake/currencies'
 
+const ABI = ['function balanceOf(address owner) view returns (uint256)']
+const IOU_ABI = ['function allowance(address owner, address spender) view returns (uint256)']
+
 export const cfgConfig = isTestEnv
   ? {
       legacy: '0x657a4556e60A6097975e2E6dDFbb399E5ee9a58b',
@@ -15,8 +18,6 @@ export const cfgConfig = isTestEnv
       iou: '0xACF3c07BeBd65d5f7d86bc0bc716026A0C523069',
       new: '0xcccccccccc33d538dbc2ee4feab0a7a1ff4e8a94',
     }
-
-const ABI = ['function balanceOf(address owner) view returns (uint256)']
 
 export const useTokenBalance = (userAddress: string | undefined) => {
   return useQuery(
@@ -48,5 +49,20 @@ export const useTokenBalance = (userAddress: string | undefined) => {
     {
       enabled: !!userAddress,
     }
+  )
+}
+
+export const useCheckAllowance = (userAddress: string | undefined) => {
+  return useQuery(
+    ['checkAllowance', userAddress],
+    async () => {
+      const provider = new BrowserProvider(window.ethereum)
+      const allowance = await new ethers.Contract(cfgConfig.legacy, IOU_ABI, provider).allowance(
+        userAddress!,
+        cfgConfig.iou
+      )
+      return new CurrencyBalance(allowance.toString(), 18).toDecimal()
+    },
+    { enabled: !!userAddress }
   )
 }

--- a/centrifuge-js/src/modules/pools.ts
+++ b/centrifuge-js/src/modules/pools.ts
@@ -3866,6 +3866,10 @@ export function getPoolsModule(inst: Centrifuge) {
                   (nativeBalance as any).data.frozen.toString(),
                   api.registry.chainDecimals[0]
                 ),
+                reserved: new CurrencyBalance(
+                  (nativeBalance as any).data.reserved.toString(),
+                  api.registry.chainDecimals[0]
+                ),
                 locked: new CurrencyBalance(
                   (nativeLocks as unknown as AccountNativeLock[]).reduce(
                     (sum, lock) => sum.add(new BN(lock.amount.toString())),


### PR DESCRIPTION
- The code was missing the reserved property thus causing the bug for some wallets, now the user won't be able to migrate if the wallet has frozen or reserved tokens. 

banner is going to show as a warning
button is going to be disabled

- Add logic so we check for allowance value during WCFG migration


