### PR TITLE
Fix sorting for maturity date

### DIFF
--- a/centrifuge-app/src/pages/Pool/Overview/HoldingsTable.tsx
+++ b/centrifuge-app/src/pages/Pool/Overview/HoldingsTable.tsx
@@ -38,7 +38,12 @@ export const HoldingsTable = ({ metadata }: { metadata: PoolMetadata | undefined
 
   const data = assetsData?.data.map((row: any) => {
     return {
-      ...Object.fromEntries(Object.entries(row).map(([key, value]) => [key.toLowerCase().split(' ').join(''), value])),
+      ...Object.fromEntries(
+        Object.entries(row).map(([key, value]) => {
+          const k = key.toLowerCase().split(' ').join('')
+          return [k, k.includes('maturitydate') ? new Date(value as string) : value]
+        })
+      ),
     }
   })
 


### PR DESCRIPTION
- Maturity date in ipfs is display with format DD/MM/YYYY - sorting in JS is most effective when the date is display as timestamp
